### PR TITLE
Fix Function is null error when renaming function parameters

### DIFF
--- a/sententia/src/main/java/nl/nfi/sententia/SententiaPlugin.java
+++ b/sententia/src/main/java/nl/nfi/sententia/SententiaPlugin.java
@@ -172,7 +172,7 @@ public class SententiaPlugin extends ProgramPlugin implements DomainObjectListen
 		while (it.hasNext()) {
 			DomainObjectChangeRecord evt = it.next();
 			// Check if we're dealing with a rename and the is applied to a function
-			if (evt.getEventType().getId() == ProgramEvent.SYMBOL_RENAMED.getId() && ((ProgramChangeRecord)evt).getObject().getClass() == FunctionSymbol.class) {				
+			if (evt.getEventType().getId() == ProgramEvent.SYMBOL_RENAMED.getId() && ((ProgramChangeRecord)evt).getObject() instanceof FunctionSymbol) {				
 				
 				Function changedFunction = currentProgram.getFunctionManager().getFunctionAt(((ProgramChangeRecord)evt).getStart());
 				

--- a/sententia/src/main/java/nl/nfi/sententia/SententiaPlugin.java
+++ b/sententia/src/main/java/nl/nfi/sententia/SententiaPlugin.java
@@ -177,8 +177,7 @@ public class SententiaPlugin extends ProgramPlugin implements DomainObjectListen
 				Function changedFunction = currentProgram.getFunctionManager().getFunctionAt(((ProgramChangeRecord)evt).getStart());
 				
 				try {
-					FunctionDescriptor changedFunctionDescriptor = new FunctionDescriptor(changedFunction);
-					sententiaAPI.addSignatureToDB(changedFunctionDescriptor);
+					sententiaAPI.addSignatureToDB(new FunctionDescriptor(changedFunction));
 				} catch (InvalidInputException | CancelledException | IOException | URISyntaxException e) {
 					String errMsg = "Failed to add function to database. Is the server running? If so, check the endpoint URL!";
 					logError(errMsg, e);

--- a/sententia/src/main/java/nl/nfi/sententia/SententiaPlugin.java
+++ b/sententia/src/main/java/nl/nfi/sententia/SententiaPlugin.java
@@ -171,7 +171,7 @@ public class SententiaPlugin extends ProgramPlugin implements DomainObjectListen
 		Iterator<DomainObjectChangeRecord> it = event.iterator();
 		while (it.hasNext()) {
 			DomainObjectChangeRecord evt = it.next();
-			// Check if we're dealing with a rename and the is applied to a function
+			// Check if we're dealing with a rename that is applied to a function
 			if (evt.getEventType().getId() == ProgramEvent.SYMBOL_RENAMED.getId() && ((ProgramChangeRecord)evt).getObject() instanceof FunctionSymbol) {				
 				
 				Function changedFunction = currentProgram.getFunctionManager().getFunctionAt(((ProgramChangeRecord)evt).getStart());

--- a/sententia/src/main/java/nl/nfi/sententia/SententiaPlugin.java
+++ b/sententia/src/main/java/nl/nfi/sententia/SententiaPlugin.java
@@ -47,6 +47,7 @@ import ghidra.framework.options.OptionsChangeListener;
 import ghidra.framework.options.ToolOptions;
 import ghidra.framework.plugintool.*;
 import ghidra.framework.plugintool.util.PluginStatus;
+import ghidra.program.database.symbol.FunctionSymbol;
 import ghidra.program.model.listing.Function;
 import ghidra.program.model.listing.FunctionIterator;
 import ghidra.program.model.listing.FunctionManager;
@@ -170,10 +171,13 @@ public class SententiaPlugin extends ProgramPlugin implements DomainObjectListen
 		Iterator<DomainObjectChangeRecord> it = event.iterator();
 		while (it.hasNext()) {
 			DomainObjectChangeRecord evt = it.next();
-			if (evt.getEventType().getId() == ProgramEvent.SYMBOL_RENAMED.getId()) {				
+			// Check if we're dealing with a rename and the is applied to a function
+			if (evt.getEventType().getId() == ProgramEvent.SYMBOL_RENAMED.getId() && ((ProgramChangeRecord)evt).getObject().getClass() == FunctionSymbol.class) {				
+				
+				Function changedFunction = currentProgram.getFunctionManager().getFunctionAt(((ProgramChangeRecord)evt).getStart());
 				
 				try {
-					FunctionDescriptor changedFunctionDescriptor = new FunctionDescriptor(currentProgram.getFunctionManager().getFunctionAt(((ProgramChangeRecord)evt).getStart()));
+					FunctionDescriptor changedFunctionDescriptor = new FunctionDescriptor(changedFunction);
 					sententiaAPI.addSignatureToDB(changedFunctionDescriptor);
 				} catch (InvalidInputException | CancelledException | IOException | URISyntaxException e) {
 					String errMsg = "Failed to add function to database. Is the server running? If so, check the endpoint URL!";


### PR DESCRIPTION
This PR fixes an error in the Ghidra Sententia plugin which occurs when renaming function variables. This happens because we don't filter the SYMBOL_RENAMED event properly. 