### PR TITLE
Update SententiaAPI to use HTTP/2 with a fallback to HTTP1.1

### DIFF
--- a/sententia/src/main/java/nl/nfi/sententia/DowngradingHTTPClient.java
+++ b/sententia/src/main/java/nl/nfi/sententia/DowngradingHTTPClient.java
@@ -1,0 +1,36 @@
+package nl.nfi.sententia;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandler;
+
+public class DowngradingHTTPClient {
+    private HttpClient client;
+
+    public DowngradingHTTPClient() {
+        // Default client with HTTP/2
+        this.client = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_2)
+                .build();
+    }
+
+    public HttpResponse<String> send(HttpRequest request, BodyHandler<String> responseBodyHandler) throws InterruptedException, IOException {
+        HttpResponse<String> response = client.send(request, responseBodyHandler);
+
+        // If server doesn't support HTTP/2, fall back to HTTP1.1
+        if (response.statusCode() == 422) {
+            // Downgrade to HTTP/1.1 and retry
+            this.client = HttpClient.newBuilder()
+                    .version(HttpClient.Version.HTTP_1_1)
+                    .build();
+
+            response = client.send(request, responseBodyHandler);
+        }
+
+        return response;
+    }
+
+    // Optional: add other convenience methods if needed
+}

--- a/sententia/src/main/java/nl/nfi/sententia/SententiaAPI.java
+++ b/sententia/src/main/java/nl/nfi/sententia/SententiaAPI.java
@@ -2,115 +2,128 @@ package nl.nfi.sententia;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
-import java.net.HttpURLConnection;
-import java.net.ProtocolException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URLConnection;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest.BodyPublishers;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Comparator;
-
-
+import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
-import org.json.simple.JSONArray;
 import org.json.simple.parser.ParseException;
 
 import ghidra.framework.plugintool.PluginTool;
 import ghidra.program.model.listing.Program;
 
 public class SententiaAPI {
-	public static final String SENTENTIA_DEFAULT_URL = "http://localhost:5000";
-	public static final String API_URL = "/api/v1";
-	private URI serverURL;
-	
-	public SententiaAPI(Program currentProgram, PluginTool sententiaTool) throws URISyntaxException {
-		this(currentProgram, new URI(sententiaTool.getOptions("SententiaPlugin").getString("Endpoint", SENTENTIA_DEFAULT_URL)));
-	}
-	
-	public SententiaAPI(Program currentProgram, URI url) {
-		this.serverURL = url;
-	}
-	
-	public void setServerURL(URI url) {
-		this.serverURL = url;
-	}
-	
-	
-	public ArrayList<SententiaResult> getMatchingFunctions(FunctionDescriptor descriptor, int top) 
-			throws IOException, ProtocolException, ParseException, URISyntaxException {
-		
-		ArrayList<SententiaResult> results = new ArrayList<SententiaResult>();
-			
-		URLConnection serverConnection;
-		
+    public static final String SENTENTIA_DEFAULT_URL = "http://localhost:5000";
+    public static final String API_URL = "/api/v1";
+    private URI serverURL;
+    private HttpClient client;
 
-		serverConnection = new URI(this.serverURL + API_URL + "/search").toURL().openConnection();
-		
-		HttpURLConnection serverHTTP = (HttpURLConnection) serverConnection;
-		
-		serverHTTP.setRequestMethod("POST");
-		serverHTTP.setDoOutput(true);
-		
-		serverHTTP.setFixedLengthStreamingMode(descriptor.toJson().toJSONString().length());
-		serverHTTP.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
-		serverHTTP.connect();
-		
-		try(OutputStream os = serverHTTP.getOutputStream()) {
-		    os.write(descriptor.toJson().toJSONString().getBytes(StandardCharsets.UTF_8));
-		}
-		
-		BufferedReader reader = new BufferedReader(new InputStreamReader(serverConnection.getInputStream()));
-		
-		JSONParser parser = new JSONParser();
+    public SententiaAPI(Program currentProgram, PluginTool sententiaTool) throws URISyntaxException {
+        this(currentProgram, new URI(sententiaTool.getOptions("SententiaPlugin").getString("Endpoint", SENTENTIA_DEFAULT_URL)));
+    }
 
-		JSONArray jsonResponse = (JSONArray) parser.parse(reader);
-		
-		
-		 for (Object result : jsonResponse) {
-			 JSONObject jsonResult = (JSONObject) result;
-			 if (jsonResult.get("function") instanceof String && jsonResult.get("similarity") instanceof Double) {
-                 results.add(new SententiaResult(
-                     (String) jsonResult.get("function"),
-                     (Double) jsonResult.get("similarity")
-                 ));
-			 } else {
-				throw new IOException("Malformed json result!");
-			 }
-		 }
-		 
-		
-		// Sort the list by score, descending
-		results.sort(Comparator.comparing(res -> res.getFunctionScore(), Comparator.nullsLast(Comparator.reverseOrder())));
-		
-		//TODO: Always return only top n results
-		return results;
-		
-	}
-	
-	public void addSignatureToDB(FunctionDescriptor descriptor) throws IOException, URISyntaxException {
-					
-		URLConnection serverConnection = new URI(serverURL.toString() + API_URL + "/add").toURL().openConnection();	 
-		
-		HttpURLConnection serverHTTP = (HttpURLConnection) serverConnection;
-		
-		serverHTTP.setRequestMethod("POST");
-		serverHTTP.setDoOutput(true);
-		
-		final byte[] payload = descriptor.toJson().toJSONString().getBytes(StandardCharsets.UTF_8);
-		
-		serverHTTP.setFixedLengthStreamingMode(payload.length);
-		serverHTTP.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
-		serverHTTP.connect();
-		
-		try(OutputStream os = serverHTTP.getOutputStream()) {
-		    os.write(payload);
-		}
-		
-		serverHTTP.disconnect();
-		
-	}
+    public SententiaAPI(Program currentProgram, URI url) {
+        this.serverURL = url;
+        // Initialize HttpClient with HTTP/2 enabled and connection reuse
+        this.client = HttpClient.newBuilder()
+                                .version(HttpClient.Version.HTTP_2)  // Force HTTP/2
+                                .build();
+    }
+
+    public void setServerURL(URI url) {
+        this.serverURL = url;
+    }
+
+    public ArrayList<SententiaResult> getMatchingFunctions(FunctionDescriptor descriptor, int top) 
+            throws IOException, ParseException, URISyntaxException, InterruptedException {
+        
+        ArrayList<SententiaResult> results = new ArrayList<>();
+        
+        // Construct the full URL
+        URI targetURI = new URI(this.serverURL.toString() + API_URL + "/search");
+
+        // Prepare the JSON payload
+        String jsonPayload = descriptor.toJson().toJSONString();
+
+        // Create HTTP request
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(targetURI)
+                .header("Content-Type", "application/json; charset=UTF-8")
+                .POST(BodyPublishers.ofString(jsonPayload, StandardCharsets.UTF_8))  // Send POST request with the JSON body
+                .build();
+
+        // Send the request and get the response
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        
+        // If server doesn't support HTTP/2, fall back to HTTP1.1
+        if (response.statusCode() == 422) {
+        	this.client = HttpClient.newBuilder()
+                    .version(HttpClient.Version.HTTP_1_1)  // Downgrade to HTTP1.1
+                    .build();
+        	response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        }
+
+        // Parse the response
+        JSONParser parser = new JSONParser();
+        JSONArray jsonResponse = (JSONArray) parser.parse(response.body());
+
+        // Process the response
+        for (Object result : jsonResponse) {
+            JSONObject jsonResult = (JSONObject) result;
+            if (jsonResult.get("function") instanceof String && jsonResult.get("similarity") instanceof Double) {
+                results.add(new SententiaResult(
+                    (String) jsonResult.get("function"),
+                    (Double) jsonResult.get("similarity")
+                ));
+            } else {
+                throw new IOException("Malformed JSON result!");
+            }
+        }
+
+        // Sort the results by similarity score in descending order
+        results.sort(Comparator.comparing(SententiaResult::getFunctionScore, Comparator.nullsLast(Comparator.reverseOrder())));
+
+        // Return the top N results if required (default is returning all)
+        return results;
+
+    }
+
+    public void addSignatureToDB(FunctionDescriptor descriptor) throws IOException, URISyntaxException, InterruptedException {
+        URI targetURI = new URI(serverURL.toString() + API_URL + "/add");
+
+        // Prepare the JSON payload
+        String jsonPayload = descriptor.toJson().toJSONString();
+
+        // Create HTTP request
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(targetURI)
+                .header("Content-Type", "application/json; charset=UTF-8")
+                .POST(BodyPublishers.ofString(jsonPayload, StandardCharsets.UTF_8))  // Send POST request with the JSON body
+                .build();
+
+        // Send the request
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        // If server doesn't support HTTP/2, fall back to HTTP1.1
+        if (response.statusCode() == 422) {
+        	this.client = HttpClient.newBuilder()
+                    .version(HttpClient.Version.HTTP_1_1)  // Downgrade to HTTP1.1
+                    .build();
+        	response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        }
+        
+        // Check if the request was successful (you can add more robust error handling here)
+        if (response.statusCode() != 200) {
+            throw new IOException("Failed to add signature to database. HTTP status code: " + response.statusCode());
+        }
+    }
 }

--- a/sententia/src/main/java/nl/nfi/sententia/SententiaAPI.java
+++ b/sententia/src/main/java/nl/nfi/sententia/SententiaAPI.java
@@ -9,6 +9,8 @@ import java.net.http.HttpRequest.BodyPublishers;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.List;
+
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -78,7 +80,6 @@ public class SententiaAPI {
         // Sort the results by similarity score in descending order
         results.sort(Comparator.comparing(SententiaResult::getFunctionScore, Comparator.nullsLast(Comparator.reverseOrder())));
 
-        // Return the top N results if required (default is returning all)
         return results;
 
     }

--- a/sententia/src/main/java/nl/nfi/sententia/SententiaAPI.java
+++ b/sententia/src/main/java/nl/nfi/sententia/SententiaAPI.java
@@ -37,7 +37,7 @@ public class SententiaAPI {
         this.serverURL = url;
     }
 
-    public ArrayList<SententiaResult> getMatchingFunctions(FunctionDescriptor descriptor, int top) 
+    public List<SententiaResult> getMatchingFunctions(FunctionDescriptor descriptor, int top) 
             throws IOException, ParseException, URISyntaxException, InterruptedException {
         
         ArrayList<SententiaResult> results = new ArrayList<>();

--- a/sententia/src/main/java/nl/nfi/sententia/SententiaAnalyzer.java
+++ b/sententia/src/main/java/nl/nfi/sententia/SententiaAnalyzer.java
@@ -75,7 +75,6 @@ public class SententiaAnalyzer extends AbstractAnalyzer {
 	@Override
 	public void optionsChanged(Options options, Program program) {
 		
-		
 		try {
 			if (this.sententiaAPI == null) {
 				this.sententiaAPI = new SententiaAPI(program, new URI(options.getString("Server URL", SententiaAPI.SENTENTIA_DEFAULT_URL)));
@@ -83,7 +82,7 @@ public class SententiaAnalyzer extends AbstractAnalyzer {
 			this.sententiaAPI.setServerURL(new URI(options.getString("Server URL", SententiaAPI.SENTENTIA_DEFAULT_URL)));
 		} catch(URISyntaxException e) {
 			Msg.showError(this, null, "Invalid endpoint URL", "The endpoint URL is invalid, please enter a valid endpoint URL.", e);
-		}		
+		}	
 	}
 
 	@Override
@@ -101,7 +100,7 @@ public class SententiaAnalyzer extends AbstractAnalyzer {
 			// Todo actually do something with the results
 			try {
 				this.sententiaAPI.getMatchingFunctions(new FunctionDescriptor(currentFunction), 25);
-			} catch (IOException | ParseException | InvalidInputException | URISyntaxException e) {
+			} catch (IOException | ParseException | InvalidInputException | URISyntaxException | InterruptedException e) {
 				e.printStackTrace();
 			}
 		}

--- a/sententia/src/main/java/nl/nfi/sententia/SententiaPlugin.java
+++ b/sententia/src/main/java/nl/nfi/sententia/SententiaPlugin.java
@@ -21,6 +21,7 @@ import java.awt.Component;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -102,12 +103,7 @@ public class SententiaPlugin extends ProgramPlugin implements DomainObjectListen
 		ToolOptions options = tool.getOptions(pluginName);
 		options.registerOption("Endpoint", SententiaAPI.SENTENTIA_DEFAULT_URL, null, "The URL for the Sententia server endpoint");
 		
-		try {
-			sententiaAPI = new SententiaAPI(this.currentProgram, tool);
-		} catch (URISyntaxException e) {
-			// TODO Actually handle this.
-			sententiaAPI = new SententiaAPI(this.currentProgram, new URI(SententiaAPI.SENTENTIA_DEFAULT_URL));
-		}
+		sententiaAPI = new SententiaAPI(this.currentProgram, tool);
 		
 		optionsChangeListener = new OptionsChangeListener() {
 			  @Override
@@ -178,7 +174,7 @@ public class SententiaPlugin extends ProgramPlugin implements DomainObjectListen
 				
 				try {
 					sententiaAPI.addSignatureToDB(new FunctionDescriptor(changedFunction));
-				} catch (InvalidInputException | CancelledException | IOException | URISyntaxException e) {
+				} catch (InvalidInputException | CancelledException | IOException | URISyntaxException | InterruptedException e) {
 					String errMsg = "Failed to add function to database. Is the server running? If so, check the endpoint URL!";
 					logError(errMsg, e);
 					return;
@@ -206,7 +202,7 @@ public class SententiaPlugin extends ProgramPlugin implements DomainObjectListen
 			FunctionDescriptor functionDescriptor = new FunctionDescriptor(currentFunction);
 			ArrayList<SententiaResult> results = sententiaAPI.getMatchingFunctions(functionDescriptor, 25);
 			displayComponent.updateSimilarFunctions(results);
-		} catch (InvalidInputException | CancelledException | IOException | ParseException | URISyntaxException e) {
+		} catch (InvalidInputException | CancelledException | IOException | ParseException | URISyntaxException | InterruptedException e) {
 			String errMsg = "Failed to get similar functions. Is the server running? If so, check the endpoint URL!";
 			logError(errMsg, e);
 			return;
@@ -319,7 +315,7 @@ public class SententiaPlugin extends ProgramPlugin implements DomainObjectListen
 						if ((!functionName.toLowerCase().startsWith("fun_")) && (!functionName.toLowerCase().startsWith("thunk"))) {
 							try {
 								api.addSignatureToDB(new FunctionDescriptor(function));
-							} catch (InvalidInputException|CancelledException|IOException|URISyntaxException e) {
+							} catch (InvalidInputException|CancelledException|IOException|URISyntaxException | InterruptedException e) {
 								// TODO Auto-generated catch block
 								e.printStackTrace();
 							}

--- a/sententia/src/main/java/nl/nfi/sententia/SententiaPlugin.java
+++ b/sententia/src/main/java/nl/nfi/sententia/SententiaPlugin.java
@@ -200,7 +200,7 @@ public class SententiaPlugin extends ProgramPlugin implements DomainObjectListen
 		
 		try {
 			FunctionDescriptor functionDescriptor = new FunctionDescriptor(currentFunction);
-			ArrayList<SententiaResult> results = sententiaAPI.getMatchingFunctions(functionDescriptor, 25);
+			ArrayList<SententiaResult> results = (ArrayList<SententiaResult>) sententiaAPI.getMatchingFunctions(functionDescriptor, 25);
 			displayComponent.updateSimilarFunctions(results);
 		} catch (InvalidInputException | CancelledException | IOException | ParseException | URISyntaxException | InterruptedException e) {
 			String errMsg = "Failed to get similar functions. Is the server running? If so, check the endpoint URL!";


### PR DESCRIPTION
Using HTTP1.0 gives a LOT of connection overhead, which is really not beneficial when trying to add thousands of functions to the database at once. By upgrading the Java client side of the API to use HTTP/2 with a fallback to HTTP/1.1, we automatically get connection reuse and other goodies, which really cuts down on the overhead.