### PR TITLE
Fix `__len__` in LazySentenceLabelDataset and add corresponding test

### DIFF
--- a/asmtransformers/asmtransformers/datasets/sentencelabel.py
+++ b/asmtransformers/asmtransformers/datasets/sentencelabel.py
@@ -66,7 +66,7 @@ class LazySentenceLabelDataset(IterableDataset):
                 yield self.example(idx)
 
     def __len__(self):
-        return sum(len(indices) for indices in self.label2rowindices.values())
+        return len(self.label2rowindices) * self.samples_per_label
 
     def example(self, idx):
         row = self.dataset[idx]

--- a/asmtransformers/tests/test_sentencelabel.py
+++ b/asmtransformers/tests/test_sentencelabel.py
@@ -1,0 +1,28 @@
+from datasets import Dataset
+
+from asmtransformers.datasets import LazySentenceLabelDataset
+
+
+def test_len_matches_number_of_yielded_examples():
+    source = Dataset.from_dict({
+        'cfg': [
+            'a-0', 'a-1',
+            'b-0', 'b-1', 'b-2', 'b-3',
+            'c-0',
+        ],
+        'label': [
+            'a', 'a',
+            'b', 'b', 'b', 'b',
+            'c',
+        ],
+    })
+
+    dataset = LazySentenceLabelDataset(source, samples_per_label=2)
+
+    yielded = list(dataset)
+
+    assert len(dataset) == 4
+    assert len(yielded) == len(dataset)
+    assert [example.label for example in yielded].count('a') == 2
+    assert [example.label for example in yielded].count('b') == 2
+    assert [example.label for example in yielded].count('c') == 0


### PR DESCRIPTION
We only yield N samples per category. The current __len__() returns the total number of eligible samples.