### PR TITLE
Align pdm run scripts with other projects

### DIFF
--- a/asmtransformers/pyproject.toml
+++ b/asmtransformers/pyproject.toml
@@ -38,13 +38,22 @@ test = [
 ]
 
 [tool.pdm.scripts]
-all = {composite = ["check", "test", "report"]}
-check = {composite = ["format", "lint"]}
-format = {cmd = "ruff format --diff asmtransformers/"}
-lint = {cmd = "ruff check asmtransformers/"}
-reformat = {cmd = "ruff format asmtransformers/"}
-report = {cmd = "coverage xml"}
-test = {cmd = "coverage run --branch --source asmtransformers --module pytest --junit-xml pytest.xml --strict-markers tests/"}
+all = {composite = [
+    "check",
+    "test",
+    "report",
+]}
+check = {composite = [
+    "pdm lock --check",
+    "ruff format --diff asmtransformers/",
+    "ruff check asmtransformers/",
+]}
+fix = {composite = [
+    "ruff format asmtransformers/",
+    "ruff check --fix asmtransformers/",
+]}
+report = "coverage report"
+test = "coverage run --branch --source asmtransformers --module pytest --junit-xml pytest.xml --strict-markers tests/"
 
 [tool.ruff]
 format.quote-style = "single"

--- a/citatio/pyproject.toml
+++ b/citatio/pyproject.toml
@@ -38,13 +38,22 @@ test = [
 ]
 
 [tool.pdm.scripts]
-all = {composite = ["check", "test", "report"]}
-check = {composite = ["format", "lint"]}
-format = {cmd = "ruff format --diff citatio/"}
-lint = {cmd = "ruff check citatio/"}
-reformat = {cmd = "ruff format citatio/"}
-report = {cmd = "coverage xml"}
-test = {cmd = "coverage run --branch --source citatio --module pytest --junit-xml pytest.xml --strict-markers tests/"}
+all = {composite = [
+    "check",
+    "test",
+    "report",
+]}
+check = {composite = [
+    "pdm lock --check",
+    "ruff format --diff citatio/",
+    "ruff check citatio/",
+]}
+fix = {composite = [
+    "ruff format citatio/",
+    "ruff check --fix citatio/",
+]}
+report = "coverage report"
+test = "coverage run --branch --source citatio --module pytest --junit-xml pytest.xml --strict-markers tests/"
 
 [tool.ruff]
 format.quote-style = "single"


### PR DESCRIPTION
We *could* include the tests with the check and format runs, which would cause a good chunk of diff. Should I include that or create another PR for that?