### PR TITLE
Rename preprocessor to arm64preprocessor

### DIFF
--- a/asmtransformers/asmtransformers/arm64.py
+++ b/asmtransformers/asmtransformers/arm64.py
@@ -58,7 +58,7 @@ BRANCH_INSTRUCTIONS += tuple(f'b.{cc}' for cc in CONDITION_CODES)
 OPERAND_SEPARATOR = re.compile(r'[,\s]+')
 
 
-class Preprocessor:
+class ARM64Preprocessor:
     def __init__(self, *, context_length=512, prefix_tokens=None, operand_formatters=None):
         self.context_length = context_length
         self.prefix_tokens = prefix_tokens or ()

--- a/asmtransformers/asmtransformers/models/asmbert.py
+++ b/asmtransformers/asmtransformers/models/asmbert.py
@@ -8,7 +8,7 @@ from transformers.modeling_outputs import MaskedLMOutput
 from transformers.models.bert.modeling_bert import BertOnlyMLMHead, BertPreTrainedModel
 
 from asmtransformers import operands
-from asmtransformers.arm64 import Preprocessor
+from asmtransformers.arm64 import ARM64Preprocessor
 
 
 class ASMBertModel(BertModel):
@@ -213,7 +213,7 @@ class ARM64Tokenizer(BertTokenizer):
         strip_accents=None,
         **kwargs,
     ):
-        self.preprocessor = Preprocessor(
+        self.preprocessor = ARM64Preprocessor(
             operand_formatters=(
                 # 2-log numerical values and offsets to reduce the number of unique tokens we'll generate
                 # (pre-made vocabulary used this too)

--- a/asmtransformers/docs/architecture.md
+++ b/asmtransformers/docs/architecture.md
@@ -96,12 +96,12 @@ The current end-to-end flow is:
 
 The following parts are tightly coupled to ARM64:
 
-- `asmtransformers.arm64.Preprocessor`
+- `asmtransformers.arm64.ARM64Preprocessor`
 - ARM64 branch instruction lists and condition-code handling
 - operand assumptions embodied in the current parser
 - `ARM64Tokenizer`
 - packaged model assets in `models/arm64bert/`
-- scripts that directly instantiate `arm64.Preprocessor`
+- scripts that directly instantiate `arm64.ARM64Preprocessor`
 
 These elements would need to be replaced or generalized for additional instruction sets.
 

--- a/asmtransformers/scripts/mkvocab.py
+++ b/asmtransformers/scripts/mkvocab.py
@@ -21,7 +21,7 @@ if __name__ == '__main__':
     print('opening dataset ...')
     dataset = datasets.load_from_disk(DATASET)
     print('... done')
-    preprocessor = arm64.Preprocessor(
+    preprocessor = arm64.ARM64Preprocessor(
         operand_formatters=(
             operands.format_immediate_log,
             operands.format_offset_log,

--- a/asmtransformers/tests/test_arm64.py
+++ b/asmtransformers/tests/test_arm64.py
@@ -10,7 +10,7 @@ from asmtransformers.models.asmbert import ARM64Tokenizer
 
 @pytest.fixture
 def tokenizer():
-    return arm64.Preprocessor()
+    return arm64.ARM64Preprocessor()
 
 
 def test_parse_no_operands():
@@ -76,7 +76,7 @@ def test_tokenize_branching_blocks(tokenizer):
 def test_context_length_boundary():
     # use a content length that would include the first two instructions, having the third instruction fall outside the
     # scope
-    tokens = arm64.Preprocessor(context_length=10).preprocess(
+    tokens = arm64.ARM64Preprocessor(context_length=10).preprocess(
         {
             0x12: ['ldp x19,x20,[sp, #0x10]', 'b 0x34'],
             0x34: ['movk x1,#0x4024, LSL #16', 'b.eq 0x56'],
@@ -115,7 +115,7 @@ def test_offset_prefix_tokens(tokenizer):
 
 
 def test_format_operand():
-    class ObfuscatingTokenizer(arm64.Preprocessor):
+    class ObfuscatingTokenizer(arm64.ARM64Preprocessor):
         def format_operand(self, operand):
             if arm64.is_offset(operand):
                 return 'OBFUSCATED'

--- a/asmtransformers/tests/test_operand_formatters.py
+++ b/asmtransformers/tests/test_operand_formatters.py
@@ -11,13 +11,13 @@ def test_full_house():
         ]
     }
 
-    tokens = arm64.Preprocessor(
+    tokens = arm64.ARM64Preprocessor(
         operand_formatters=(
             operands.format_immediate_log,
             operands.format_offset_log,
         )
     ).preprocess(graph)
-    tokens_plain = arm64.Preprocessor().preprocess(graph)
+    tokens_plain = arm64.ARM64Preprocessor().preprocess(graph)
 
     assert len(tokens) == len(tokens_plain)
     assert tokens != tokens_plain


### PR DESCRIPTION
Renaming to arm64preprocessor to prepare repo for a x86 preprocessor and tokenizer