### PR TITLE
Align x86 operands parsing with other parsers

### DIFF
--- a/asmtransformers/asmtransformers/preprocessors/x86.py
+++ b/asmtransformers/asmtransformers/preprocessors/x86.py
@@ -106,7 +106,7 @@ class X86Preprocessor(ASMPreprocessor):
                         assert rest.lstrip().startswith('ptr')
                         yield f'{token}_ptr'
                         # continue after "ptr"
-                        offset = end + rest.index('ptr') + 3
+                        offset = end + rest.index('ptr') + 3  # len('ptr')
                     else:
                         # strip optional segment-override suffix ":" from the token
                         # TODO: would it be informational to keep that suffix instead?

--- a/asmtransformers/asmtransformers/preprocessors/x86.py
+++ b/asmtransformers/asmtransformers/preprocessors/x86.py
@@ -68,10 +68,8 @@ SIZE_QUALIFIERS = {
 }
 
 
-# a separator between operands; commas, whitespaces, memory expressions or a combination of these
-OPERAND_SEPARATOR = re.compile(r'[,\s\[\]]+')
-# Matches one token that stops before commas, spaces, or memory-expression operators
-_OPERAND_TOKEN = re.compile(r'[^\s,+\-*\[\]]+')
+# a separator between operands; commas, whitespaces, memory expression start/end/operator or a combination of these
+OPERAND_SEPARATOR = re.compile(r'[,\s\[\]+\-*]+')
 
 
 class X86Preprocessor(ASMPreprocessor):
@@ -114,38 +112,31 @@ class X86Preprocessor(ASMPreprocessor):
                         yield token.removesuffix(':')
                         offset = end
 
-
-    def parse_memory_expression(self, expr: str) -> Iterator[str]:
+    def parse_memory_expression(self, expression: str) -> Iterator[str]:
         """
         We need this because subtracting a memory expression in ghidra is done by [rbp + -0x8].
         Split a memory address expression into tokens.
         treating negative displacements like "-0x8" as a single token rather than an operator followed by a number.
         """
         offset = 0
-        length = len(expr)
+        length = len(expression)
 
         while offset < length:
-            match expr[offset]:
+            match expression[offset]:
                 case ' ':
                     offset += 1
-                case '+' | '*':
-                    yield expr[offset]
-                    offset += 1
-                case '-':
-                    # unary minus: attach to the number that follows when preceded by an operator or start
-                    prev = expr[:offset].rstrip()
-                    if not prev or prev[-1] in ('+', '-', '*'):
-                        m = _OPERAND_TOKEN.match(expr, offset + 1)
-                        if m:
-                            yield f'-{m.group().lower()}'
-                            offset = m.end()
-                            continue
-                    yield '-'
+                case '-' if not (preceding := expression[:offset].rstrip()) or preceding[-1] in '+-*':
+                    # a negative displacement, treat it as an operand starting with "-" instead of an operator
+                    # NB: search for the end of the operand *after* the "-"
+                    end = sep.start() if (sep := OPERAND_SEPARATOR.search(expression, offset + 1)) else len(expression)
+                    yield expression[offset:end]
+                    offset = end
+                case '+' | '*' | '-' as operator:
+                    yield operator
                     offset += 1
                 case _:
-                    m = _OPERAND_TOKEN.match(expr, offset)
-                    if m:
-                        yield m.group().lower()
-                        offset = m.end()
-                    else:
-                        offset += 1
+                    # any other case is 'just an operand'
+                    # find the starting index of the separator; marking the end of the current operand
+                    end = sep.start() if (sep := OPERAND_SEPARATOR.search(expression, offset)) else len(expression)
+                    yield expression[offset:end]
+                    offset = end

--- a/asmtransformers/asmtransformers/preprocessors/x86.py
+++ b/asmtransformers/asmtransformers/preprocessors/x86.py
@@ -5,7 +5,7 @@ from asmtransformers.preprocessors import ASMPreprocessor
 
 
 # based mostly on: https://en.wikipedia.org/wiki/List_of_x86_instructions
-BRANCH_INSTRUCTIONS = (
+BRANCH_INSTRUCTIONS = {
     # unconditional jump and call/return
     'jmp',
     'call',
@@ -53,7 +53,7 @@ BRANCH_INSTRUCTIONS = (
     'loop',
     'loope',
     'loopne',
-)
+}
 
 
 SIZE_QUALIFIERS = {
@@ -68,11 +68,10 @@ SIZE_QUALIFIERS = {
 }
 
 
+# a separator between operands; commas, whitespaces, memory expressions or a combination of these
+OPERAND_SEPARATOR = re.compile(r'[,\s\[\]]+')
 # Matches one token that stops before commas, spaces, or memory-expression operators
 _OPERAND_TOKEN = re.compile(r'[^\s,+\-*\[\]]+')
-
-
-_MEM_OPERATORS = frozenset('+-*')
 
 
 class X86Preprocessor(ASMPreprocessor):
@@ -85,37 +84,36 @@ class X86Preprocessor(ASMPreprocessor):
         while offset < length:
             match operands[offset]:
                 case ' ' | ',':
+                    # treat both spaces and commas as separators (skip these tokens)
                     offset += 1
                 case '[':
+                    # expression between square brackets is a memory expression
+                    # slice this out of the operands string and process it separately
                     end = operands.index(']', offset)
                     yield '['
                     yield from self.parse_memory_expression(operands[offset + 1 : end].strip())
                     yield ']'
                     offset = end + 1
-                case ch if ch in _MEM_OPERATORS:
-                    yield ch
-                    offset += 1
                 case _:
-                    m = _OPERAND_TOKEN.match(operands, offset)
-                    if not m:
-                        offset += 1
-                        continue
+                    # any other case is 'just an operand'
+                    # find the starting index of the separator; marking the end of the current operand
+                    end = sep.start() if (sep := OPERAND_SEPARATOR.search(operands, offset)) else len(operands)
+                    token = operands[offset:end]
 
-                    token = m.group().rstrip(':')  # strip segment-override colon (e.g. "fs:")
-                    lower = token.lower()
-
-                    if lower in SIZE_QUALIFIERS:
+                    if token in SIZE_QUALIFIERS:
                         # consume the mandatory following "ptr" keyword and merge into one token
-                        rest = operands[m.end() :].lstrip()
-                        if rest.lower().startswith('ptr'):
-                            yield f'{lower}_ptr'
-                            offset = m.end() + (len(operands[m.end() :]) - len(rest)) + 3
-                        else:
-                            yield lower
-                            offset = m.end()
+                        rest = operands[end:]
+                        # NB: a size qualifier *should* be followed by "ptr"
+                        assert rest.lstrip().startswith('ptr')
+                        yield f'{token}_ptr'
+                        # continue after "ptr"
+                        offset = end + rest.index('ptr') + 3
                     else:
-                        yield lower
-                        offset = m.end()
+                        # strip optional segment-override suffix ":" from the token
+                        # TODO: would it be informational to keep that suffix instead?
+                        yield token.removesuffix(':')
+                        offset = end
+
 
     def parse_memory_expression(self, expr: str) -> Iterator[str]:
         """

--- a/asmtransformers/asmtransformers/preprocessors/x86.py
+++ b/asmtransformers/asmtransformers/preprocessors/x86.py
@@ -70,6 +70,7 @@ SIZE_QUALIFIERS = {
 
 # a separator between operands; commas, whitespaces, memory expression start/end/operator or a combination of these
 OPERAND_SEPARATOR = re.compile(r'[,\s\[\]+\-*]+')
+MEMORY_OPERATORS = {'+', '-', '*'}
 
 
 class X86Preprocessor(ASMPreprocessor):
@@ -125,7 +126,7 @@ class X86Preprocessor(ASMPreprocessor):
             match expression[offset]:
                 case ' ':
                     offset += 1
-                case '-' if not (preceding := expression[:offset].rstrip()) or preceding[-1] in '+-*':
+                case '-' if not (preceding := expression[:offset].rstrip()) or preceding[-1] in MEMORY_OPERATORS:
                     # a negative displacement, treat it as an operand starting with "-" instead of an operator
                     # NB: search for the end of the operand *after* the "-"
                     end = sep.start() if (sep := OPERAND_SEPARATOR.search(expression, offset + 1)) else len(expression)

--- a/asmtransformers/asmtransformers/preprocessors/x86.py
+++ b/asmtransformers/asmtransformers/preprocessors/x86.py
@@ -89,7 +89,7 @@ class X86Preprocessor(ASMPreprocessor):
                 case '[':
                     end = operands.index(']', offset)
                     yield '['
-                    yield from self.parse_memory_expression(operands[offset + 1 : end])
+                    yield from self.parse_memory_expression(operands[offset + 1 : end].strip())
                     yield ']'
                     offset = end + 1
                 case ch if ch in _MEM_OPERATORS:
@@ -123,32 +123,31 @@ class X86Preprocessor(ASMPreprocessor):
         Split a memory address expression into tokens.
         treating negative displacements like "-0x8" as a single token rather than an operator followed by a number.
         """
-        expr = expr.strip()
-        i = 0
+        offset = 0
         length = len(expr)
 
-        while i < length:
-            match expr[i]:
+        while offset < length:
+            match expr[offset]:
                 case ' ':
-                    i += 1
+                    offset += 1
                 case '+' | '*':
-                    yield expr[i]
-                    i += 1
+                    yield expr[offset]
+                    offset += 1
                 case '-':
                     # unary minus: attach to the number that follows when preceded by an operator or start
-                    prev = expr[:i].rstrip()
+                    prev = expr[:offset].rstrip()
                     if not prev or prev[-1] in ('+', '-', '*'):
-                        m = _OPERAND_TOKEN.match(expr, i + 1)
+                        m = _OPERAND_TOKEN.match(expr, offset + 1)
                         if m:
                             yield f'-{m.group().lower()}'
-                            i = m.end()
+                            offset = m.end()
                             continue
                     yield '-'
-                    i += 1
+                    offset += 1
                 case _:
-                    m = _OPERAND_TOKEN.match(expr, i)
+                    m = _OPERAND_TOKEN.match(expr, offset)
                     if m:
                         yield m.group().lower()
-                        i = m.end()
+                        offset = m.end()
                     else:
-                        i += 1
+                        offset += 1

--- a/asmtransformers/tests/test_x86.py
+++ b/asmtransformers/tests/test_x86.py
@@ -18,12 +18,12 @@ def test_parse_plain_operands(tokenizer):
 
 def test_parse_memory_operand(tokenizer):
     assert list(tokenizer.parse_operands('[rax]')) == ['[', 'rax', ']']
-    assert list(tokenizer.parse_operands('[rbp + -0x8]')) == ['[', 'rbp', '+', '-0x8', ']']
+    assert list(tokenizer.parse_operands('[rbp+-0x8]')) == ['[', 'rbp', '+', '-0x8', ']']
 
 
 def test_parse_size_qualifier(tokenizer):
     assert list(tokenizer.parse_operands('dword ptr [rbp + -0x8]')) == ['dword_ptr', '[', 'rbp', '+', '-0x8', ']']
-    assert list(tokenizer.parse_operands('xmmword ptr [rax]')) == ['xmmword_ptr', '[', 'rax', ']']
+    assert list(tokenizer.parse_operands('xmmword   ptr [rax]')) == ['xmmword_ptr', '[', 'rax', ']']
 
 
 def test_parse_segment_override(tokenizer):

--- a/asmtransformers/tests/test_x86.py
+++ b/asmtransformers/tests/test_x86.py
@@ -23,6 +23,8 @@ def test_parse_memory_operand(tokenizer):
 
 def test_parse_size_qualifier(tokenizer):
     assert list(tokenizer.parse_operands('dword ptr [rbp + -0x8]')) == ['dword_ptr', '[', 'rbp', '+', '-0x8', ']']
+    assert list(tokenizer.parse_operands('dword ptr [rbp - 0x8]')) == ['dword_ptr', '[', 'rbp', '-', '0x8', ']']
+    assert list(tokenizer.parse_operands('dword ptr [rbp-0x8]')) == ['dword_ptr', '[', 'rbp', '-', '0x8', ']']
     assert list(tokenizer.parse_operands('xmmword   ptr [rax]')) == ['xmmword_ptr', '[', 'rax', ']']
 
 
@@ -45,7 +47,6 @@ def test_parse_complex_memory(tokenizer):
 
 
 def test_tokenize_single_block(tokenizer):
-
     graph = {0: ['mov rax, 0x1234', 'add rax, 0x1234', 'ret']}
 
     assert tokenizer.preprocess(graph) == [
@@ -60,7 +61,6 @@ def test_tokenize_single_block(tokenizer):
 
 
 def test_tokenize_branching_blocks(tokenizer):
-
     # NB: nodes are in 'reverse order', tokenizer should reorder these based on their node ids
     graph = {42: ['add rcx, 0x290', 'je 0x0'], 0: ['sub rcx, 0x290', 'jmp 0x2a']}  # branch to offset 0
 


### PR DESCRIPTION
Mostly: 

- searching for the next separator over searching for the end of an operand;
- using the same local var names as other parsers;
- adding some comments where non-simple things are happening;
- splitting some if/elif/else things into more cases inside match.

I'd have liked to do more of the last point, but the case guard would get too complex.

`x86.py` now has 100% test coverage too 🥳 