### PR TITLE
let tokenize_dataset also accept of type datasets.Dataset

### DIFF
--- a/asmtransformers/scripts/tokenize_dataset.py
+++ b/asmtransformers/scripts/tokenize_dataset.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
     dataset = datasets.load_from_disk(data_in)
 
     # let the tokenizer preprocess data from data_in, write the result to data_out
-    for subset in dataset:
-        dataset[subset] = tokenize(tokenizer, dataset[subset])
+    # for subset in dataset:
+    dataset = tokenize(tokenizer, dataset)
 
     dataset.save_to_disk(data_out)

--- a/asmtransformers/scripts/tokenize_dataset.py
+++ b/asmtransformers/scripts/tokenize_dataset.py
@@ -25,7 +25,11 @@ if __name__ == '__main__':
     dataset = datasets.load_from_disk(data_in)
 
     # let the tokenizer preprocess data from data_in, write the result to data_out
-    # for subset in dataset:
-    dataset = tokenize(tokenizer, dataset)
+
+    if isinstance(dataset, datasets.Dataset):  # datasets.load_from_disk either a Dataset or DatasetDict type
+        dataset = tokenize(tokenizer, dataset)
+    else:
+        for subset in dataset:
+            dataset[subset] = tokenize(tokenizer, dataset[subset])
 
     dataset.save_to_disk(data_out)


### PR DESCRIPTION
Small type check in tokenize_dataset that also accepts type of datasets.Dataset as input to make a tokenized dataset when a train/test split has not happened yet. 