### PR TITLE
normalize argparse in /scripts

### DIFF
--- a/asmtransformers/scripts/evaluation.py
+++ b/asmtransformers/scripts/evaluation.py
@@ -216,8 +216,8 @@ def run_tests(data_folder, output_path, pool_size, static_pool, architecture):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='evaluation')
-    parser.add_argument('--input-path', type=str, help='the path to the test data')
-    parser.add_argument('--output-path', type=str, help='the path to write the final scores to')
+    parser.add_argument('input_path', type=str, help='the path to the test data')
+    parser.add_argument('output_path', type=str, help='the path to write the final scores to')
     parser.add_argument('--pool-size', type=int, help='the poolsize to pick the positive example from')
     parser.add_argument('--architecture', type=str, help='only use examples from specified architecture')
     parser.add_argument(

--- a/asmtransformers/scripts/finetune.py
+++ b/asmtransformers/scripts/finetune.py
@@ -126,7 +126,7 @@ def main(data_folder, model, batch_size):
 
 def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
-    parser.add_argument('data_folder', type=str, help='folder with data')
+    parser.add_argument('data_folder', type=str, help='folder with input data')
 
     parser.add_argument('model', type=str, help='The name of the model used for finetuning')
 

--- a/asmtransformers/scripts/finetune.py
+++ b/asmtransformers/scripts/finetune.py
@@ -126,9 +126,9 @@ def main(data_folder, model, batch_size):
 
 def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
-    parser.add_argument('-d', '--data-folder', type=str, required=True, help='folder with data')
+    parser.add_argument('data_folder', type=str, help='folder with data')
 
-    parser.add_argument('-m', '--model', type=str, required=True, help='The name of the model used for finetuning')
+    parser.add_argument('model', type=str, help='The name of the model used for finetuning')
 
     parser.add_argument(
         '-b',

--- a/asmtransformers/scripts/ft-datasets.py
+++ b/asmtransformers/scripts/ft-datasets.py
@@ -95,8 +95,8 @@ def main(data_folder, output_folder):
 
 def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(add_help=False)
-    parser.add_argument('-d', '--data-folder', type=str, required=True, help='folder with data')
-    parser.add_argument('-o', '--output-folder', type=str, required=True, help='folder with data')
+    parser.add_argument('data_folder', type=str, help='folder with data')
+    parser.add_argument('output_folder', type=str, help='folder with data')
     return parser
 
 

--- a/asmtransformers/scripts/ft-datasets.py
+++ b/asmtransformers/scripts/ft-datasets.py
@@ -95,8 +95,8 @@ def main(data_folder, output_folder):
 
 def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(add_help=False)
-    parser.add_argument('data_folder', type=str, help='folder with data')
-    parser.add_argument('output_folder', type=str, help='folder with data')
+    parser.add_argument('data_folder', type=str, help='folder with input data')
+    parser.add_argument('output_folder', type=str, help='folder to leave output data')
     return parser
 
 

--- a/asmtransformers/scripts/inference.py
+++ b/asmtransformers/scripts/inference.py
@@ -22,7 +22,7 @@ def get_parser() -> argparse.ArgumentParser:
     parser.add_argument('data_folder', type=str, help='folder with data')
     parser.add_argument('output_folder', type=str, help='folder with data')
 
-    parser.add_argument('model-path', type=str, help='model')
+    parser.add_argument('model_path', type=str, help='model')
     return parser
 
 

--- a/asmtransformers/scripts/inference.py
+++ b/asmtransformers/scripts/inference.py
@@ -19,10 +19,10 @@ def main(data_folder, output_folder, model_path):
 
 def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(add_help=False)
-    parser.add_argument('-d', '--data-folder', type=str, required=True, help='folder with data')
-    parser.add_argument('-o', '--output-folder', type=str, required=True, help='folder with data')
+    parser.add_argument('data_folder', type=str, help='folder with data')
+    parser.add_argument('output_folder', type=str, help='folder with data')
 
-    parser.add_argument('-m', '--model-path', type=str, required=True, help='model')
+    parser.add_argument('model-path', type=str, help='model')
     return parser
 
 

--- a/asmtransformers/scripts/inference.py
+++ b/asmtransformers/scripts/inference.py
@@ -19,8 +19,8 @@ def main(data_folder, output_folder, model_path):
 
 def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(add_help=False)
-    parser.add_argument('data_folder', type=str, help='folder with data')
-    parser.add_argument('output_folder', type=str, help='folder with data')
+    parser.add_argument('data_folder', type=str, help='folder with input data')
+    parser.add_argument('output_folder', type=str, help='folder to leave output data')
 
     parser.add_argument('model_path', type=str, help='model')
     return parser

--- a/asmtransformers/scripts/tokenize_dataset.py
+++ b/asmtransformers/scripts/tokenize_dataset.py
@@ -38,9 +38,9 @@ def main(tokenizer, input_data, output_folder, split):
 def get_parser():
     parser = argparse.ArgumentParser()
 
-    parser.add_argument('--tokenizer', type=str, required=True, help='folder with tokenizer')
-    parser.add_argument('--input-data', type=str, required=True, help='data to be used for training')
-    parser.add_argument('--output-folder', type=str, required=True, help='folder to leave the tokenized data')
+    parser.add_argument('input_data', type=str, help='data to be used for training')
+    parser.add_argument('output_folder', type=str, help='folder to leave the tokenized data')
+    parser.add_argument('tokenizer', type=str, help='folder with tokenizer')
     parser.add_argument(
         '--split',
         type=float,


### PR DESCRIPTION
input & output args are now  always positional arguments (thus no --something or -s)
sometimes model/tokenizer are also positional, if they were required anyways