### PR TITLE
Feature/exclude crosslingual eval

### DIFF
--- a/asmtransformers/scripts/evaluation.py
+++ b/asmtransformers/scripts/evaluation.py
@@ -278,14 +278,14 @@ if __name__ == '__main__':
     args = parser.parse_args()
     try:
         run_tests(
-            data_folder = args.input_path,
-            output_path = args.output_path,
-            pool_size = args.pool_size,
-            static_pool= args.static_pool,
-            crosslingual= args.crosslingual,
-            architecture = args.architecture,
-            seed = args.seed,
-            repeats = args.repeats,
+            data_folder=args.input_path,
+            output_path=args.output_path,
+            pool_size=args.pool_size,
+            static_pool=args.static_pool,
+            crosslingual=args.crosslingual,
+            architecture=args.architecture,
+            seed=args.seed,
+            repeats=args.repeats,
         )
     except ValueError as error:
         parser.error(str(error))

--- a/asmtransformers/scripts/evaluation.py
+++ b/asmtransformers/scripts/evaluation.py
@@ -64,7 +64,7 @@ def generate_neg_pool(pool_size, dataset, anchor_labels, anchor_cfgs, pos_cfgs):
     return np.array(neg_embeddings)
 
 
-def generate_triplets(dataset, pool_size, static_pool):
+def generate_triplets(dataset, pool_size, static_pool, crosslingual):
     """generates triplets consisting of an anchor, a positive example and a pool of negative examples, while making
     sure that none of the negative examples contain the same cfg as the positive and anchor they are linked to.
     Also check that the anchor and pos are not exactly the same.
@@ -115,6 +115,10 @@ def generate_triplets(dataset, pool_size, static_pool):
             # same content, reject
             rejected += 1
             continue
+        # if we don't want to evaluate crosslingual anchor/pos pairs
+        if not crosslingual and anchor['architecture'] != pos['architecture']:
+            rejected += 1
+            continue
 
         anchors.append(anchor)
         positives.append(pos)
@@ -133,12 +137,13 @@ def generate_triplets(dataset, pool_size, static_pool):
             yield {'anchor': anchors[i], 'pos': positives[i], 'negs': pool}
 
 
-def generate_test_pools(data_folder, pool_size, static_pool, architecture=None):
+def generate_test_pools(data_folder, pool_size, static_pool, architecture=None, crosslingual=False):
     """order data in such a way that we can make triplets consisting of an anchor, a positive and pool_size * negative
     examples, then call generate_triplets() to generate said triplets
     :param data_folder: Path to data
     :param pool_size: number of negative items to compare with
     :param static_pool: use the same pool of negatives for every pos/anchor pair (faster)
+    :param crosslingual: allow pos/anchor pairs to be from different architectures
 
     return
     Generator yielding triplets: anchor, positive, numpy.array(negative_embeddings * POOL_SIZE)"""
@@ -152,7 +157,9 @@ def generate_test_pools(data_folder, pool_size, static_pool, architecture=None):
     test_functions = dataset.map(add_label, batch_size=10000, num_proc=8)
     print('Sorting dataset')
     test_functions = test_functions.sort('label')
-    yield from generate_triplets(dataset=test_functions, pool_size=pool_size, static_pool=static_pool)
+    yield from generate_triplets(
+        dataset=test_functions, pool_size=pool_size, static_pool=static_pool, crosslingual=crosslingual
+    )
 
 
 def calculate_one_rank(row):
@@ -203,9 +210,11 @@ def calculate_all(test_pools, output_path, output_file):
             csvfile.flush()
 
 
-def run_tests(data_folder, output_path, pool_size, static_pool, architecture):
+def run_tests(data_folder, output_path, pool_size, static_pool, architecture, crosslingual):
     print('\ngenerate test_pools\n')
-    test_pools = generate_test_pools(data_folder, pool_size, static_pool=static_pool, architecture=architecture)
+    test_pools = generate_test_pools(
+        data_folder, pool_size, static_pool=static_pool, architecture=architecture, crosslingual=crosslingual
+    )
     print('\ncalculate cosine similarities\n')
     model_name = data_folder.split('/')[-1]
     output_file = f'{model_name}-{pool_size}-{static_pool}-{timestamp()}'
@@ -223,6 +232,12 @@ if __name__ == '__main__':
     parser.add_argument(
         '--static-pool', action='store_true', help='keep the negatives pool or refresh for every anchor-pos pair'
     )
+    parser.add_argument(
+        '--crosslingual',
+        action='store_true',
+        help='allow positive/anchor-pairs to be from different architectures (negative pools are still multilingual, '
+        'if you do not want this, run evaluation per architecture with --architecture)',
+    )
 
     args = parser.parse_args()
-    run_tests(args.input_path, args.output_path, args.pool_size, args.static_pool, args.architecture)
+    run_tests(args.input_path, args.output_path, args.pool_size, args.static_pool, args.architecture, args.crosslingual)

--- a/asmtransformers/scripts/evaluation.py
+++ b/asmtransformers/scripts/evaluation.py
@@ -278,14 +278,14 @@ if __name__ == '__main__':
     args = parser.parse_args()
     try:
         run_tests(
-            args.input_path,
-            args.output_path,
-            args.pool_size,
-            args.static_pool,
-            args.crosslingual,
-            args.architecture,
-            args.seed,
-            args.repeats,
+            data_folder = args.input_path,
+            output_path = args.output_path,
+            pool_size = args.pool_size,
+            static_pool= args.static_pool,
+            crosslingual= args.crosslingual,
+            architecture = args.architecture,
+            seed = args.seed,
+            repeats = args.repeats,
         )
     except ValueError as error:
         parser.error(str(error))

--- a/asmtransformers/scripts/evaluation.py
+++ b/asmtransformers/scripts/evaluation.py
@@ -115,7 +115,7 @@ def generate_triplets(dataset, pool_size, static_pool, crosslingual):
             # same content, reject
             rejected += 1
             continue
-        # if we don't want to evaluate crosslingual anchor/pos pairs
+        # if we want monolingual anchor/pos pairs, check if they have the same architecture:
         if not crosslingual and anchor['architecture'] != pos['architecture']:
             rejected += 1
             continue
@@ -235,8 +235,8 @@ if __name__ == '__main__':
     parser.add_argument(
         '--crosslingual',
         action='store_true',
-        help='allow positive/anchor-pairs to be from different architectures (negative pools are still multilingual, '
-        'if you do not want this, run evaluation per architecture with --architecture)',
+        help='allow positive/anchor-pairs to be from different architectures. (even without this flag, negative pools '
+        'are still multilingual, if you want monolingual negs, run evaluation per architecture with --architecture)',
     )
 
     args = parser.parse_args()

--- a/asmtransformers/scripts/ft-datasets.py
+++ b/asmtransformers/scripts/ft-datasets.py
@@ -6,7 +6,7 @@ from datasets import Dataset, DatasetDict
 from tqdm import tqdm
 
 
-def generate_train(data_folder):
+def generate_train(data_folder, crosslingual):
     train_data_folder = os.path.join(data_folder, 'train')
 
     print('Opening dataset')
@@ -14,12 +14,17 @@ def generate_train(data_folder):
 
     print('Creating category mapping')
 
-    def label_name_mapper(example):
-        label = example['file_name'] + '/' + example['function_name']
+    def label_name_mapper(example, crosslingual):
+        if not crosslingual:
+            # architecture at the end, because we will sort this dataset before finetuning and we don't want to
+            # finetune one language at the time
+            label = example['file_name'] + '/' + example['function_name'] + '/' + example['architecture']
+        else:
+            label = example['file_name'] + '/' + example['function_name']
         example['label_name'] = label
         return example
 
-    train_functions = train_functions.map(label_name_mapper, batch_size=1000, num_proc=8)
+    train_functions = train_functions.map(label_name_mapper, batch_size=1000, num_proc=8, fn_kwargs={'crosslingual': crosslingual})
     unique_labels = train_functions.unique('label_name')
     label2id = {label: i for i, label in enumerate(unique_labels)}
     print(label2id)
@@ -34,14 +39,20 @@ def generate_train(data_folder):
     return train_functions
 
 
-def generate_eval(data_folder, output_folder):
+def generate_eval(data_folder, output_folder, crosslingual):
     test_data_folder = os.path.join(data_folder, 'test')
 
     print('Opening dataset')
     test_functions = Dataset.load_from_disk(test_data_folder).select(range(1000000))
     print(test_functions)
 
-    def add_random(example):
+    def add_random(example, crosslingual):
+        if not crosslingual:
+            # architecture at the end, because we will sort this dataset before finetuning and we don't want to
+            # finetune one language at the time
+            label = example['file_name'] + '/' + example['function_name'] + '/' + example['architecture']
+        else:
+            label = example['file_name'] + '/' + example['function_name']
         label = example['file_name'] + '/' + example['function_name']
         example['label'] = label
         # Ensure same labels are sorted together and in random order.
@@ -50,7 +61,7 @@ def generate_eval(data_folder, output_folder):
 
     print('Adding columns')
     # Don't use all 3M examples because sort is really slow.
-    test_functions = test_functions.map(add_random, batch_size=10000, num_proc=8)
+    test_functions = test_functions.map(add_random, batch_size=10000, num_proc=8, fn_kwargs={'crosslingual': crosslingual})
     print('Sorting dataset')
     test_functions = test_functions.sort('label')
 
@@ -86,9 +97,9 @@ def generate_eval(data_folder, output_folder):
     return trip
 
 
-def main(data_folder, output_folder):
-    train = generate_train(data_folder)
-    test = generate_eval(data_folder, output_folder)
+def main(data_folder, output_folder, crosslingual):
+    train = generate_train(data_folder, crosslingual)
+    test = generate_eval(data_folder, output_folder, crosslingual)
     dataset_dict = DatasetDict({'train': train, 'test': test})
     dataset_dict.save_to_disk(output_folder)
 
@@ -97,6 +108,7 @@ def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument('-d', '--data-folder', type=str, required=True, help='folder with data')
     parser.add_argument('-o', '--output-folder', type=str, required=True, help='folder with data')
+    parser.add_argument('-c', '--crosslingual', action='store_true', help='evaluate similar functions across architectures')
     return parser
 
 

--- a/asmtransformers/scripts/ft-datasets.py
+++ b/asmtransformers/scripts/ft-datasets.py
@@ -6,7 +6,7 @@ from datasets import Dataset, DatasetDict
 from tqdm import tqdm
 
 
-def generate_train(data_folder, crosslingual):
+def generate_train(data_folder):
     train_data_folder = os.path.join(data_folder, 'train')
 
     print('Opening dataset')
@@ -14,17 +14,12 @@ def generate_train(data_folder, crosslingual):
 
     print('Creating category mapping')
 
-    def label_name_mapper(example, crosslingual):
-        if not crosslingual:
-            # architecture at the end, because we will sort this dataset before finetuning and we don't want to
-            # finetune one language at the time
-            label = example['file_name'] + '/' + example['function_name'] + '/' + example['architecture']
-        else:
-            label = example['file_name'] + '/' + example['function_name']
+    def label_name_mapper(example):
+        label = example['file_name'] + '/' + example['function_name']
         example['label_name'] = label
         return example
 
-    train_functions = train_functions.map(label_name_mapper, batch_size=1000, num_proc=8, fn_kwargs={'crosslingual': crosslingual})
+    train_functions = train_functions.map(label_name_mapper, batch_size=1000, num_proc=8)
     unique_labels = train_functions.unique('label_name')
     label2id = {label: i for i, label in enumerate(unique_labels)}
     print(label2id)
@@ -39,20 +34,14 @@ def generate_train(data_folder, crosslingual):
     return train_functions
 
 
-def generate_eval(data_folder, output_folder, crosslingual):
+def generate_eval(data_folder, output_folder):
     test_data_folder = os.path.join(data_folder, 'test')
 
     print('Opening dataset')
     test_functions = Dataset.load_from_disk(test_data_folder).select(range(1000000))
     print(test_functions)
 
-    def add_random(example, crosslingual):
-        if not crosslingual:
-            # architecture at the end, because we will sort this dataset before finetuning and we don't want to
-            # finetune one language at the time
-            label = example['file_name'] + '/' + example['function_name'] + '/' + example['architecture']
-        else:
-            label = example['file_name'] + '/' + example['function_name']
+    def add_random(example):
         label = example['file_name'] + '/' + example['function_name']
         example['label'] = label
         # Ensure same labels are sorted together and in random order.
@@ -61,7 +50,7 @@ def generate_eval(data_folder, output_folder, crosslingual):
 
     print('Adding columns')
     # Don't use all 3M examples because sort is really slow.
-    test_functions = test_functions.map(add_random, batch_size=10000, num_proc=8, fn_kwargs={'crosslingual': crosslingual})
+    test_functions = test_functions.map(add_random, batch_size=10000, num_proc=8)
     print('Sorting dataset')
     test_functions = test_functions.sort('label')
 
@@ -97,9 +86,9 @@ def generate_eval(data_folder, output_folder, crosslingual):
     return trip
 
 
-def main(data_folder, output_folder, crosslingual):
-    train = generate_train(data_folder, crosslingual)
-    test = generate_eval(data_folder, output_folder, crosslingual)
+def main(data_folder, output_folder):
+    train = generate_train(data_folder)
+    test = generate_eval(data_folder, output_folder)
     dataset_dict = DatasetDict({'train': train, 'test': test})
     dataset_dict.save_to_disk(output_folder)
 
@@ -108,7 +97,6 @@ def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument('-d', '--data-folder', type=str, required=True, help='folder with data')
     parser.add_argument('-o', '--output-folder', type=str, required=True, help='folder with data')
-    parser.add_argument('-c', '--crosslingual', action='store_true', help='evaluate similar functions across architectures')
     return parser
 
 


### PR DESCRIPTION
Seems like most of the features we decided we wanted are already in the code. Added functionality to do multilingual evaluation. So here are the options now:
* monolingual: anchor/pos/neg all same architecture. run evaluation.py with the --architecture flag for each architecture
* multilingual: anchor/pos from same architecture, neg multilingual. run evaluation.py
* crosslingual: anchor/pos/neg can all be from different architectures. run evaluation.py with --crosslingual flag

CAREFUL: not fully tested, creating embeddings takes a long time (I'm letting it run over the weekend)