### PR TITLE
inference takes embeddings from token ids instead of tokenizing the data

### DIFF
--- a/asmtransformers/asmtransformers/models/embedder.py
+++ b/asmtransformers/asmtransformers/models/embedder.py
@@ -46,7 +46,7 @@ class ASMEmbedder:
 
         embeddings = []
         with torch.no_grad():
-            for batch in batched(sentences, batch_size, strict=False):
+            for batch in tqdm(batched(sentences, batch_size, strict=False)):
                 inputs = self.tokenizer(batch, architecture=architecture)
                 inputs = {key: value.to(self.device) for key, value in inputs.items()}
                 outputs = self.model(**inputs)

--- a/asmtransformers/asmtransformers/models/embedder.py
+++ b/asmtransformers/asmtransformers/models/embedder.py
@@ -60,3 +60,39 @@ class ASMEmbedder:
         if convert_to_numpy:
             return embeddings.numpy().astype(np.float32, copy=False)
         return embeddings
+
+    def turn_into_tensors(self, batch, device):
+        # there might be a smarter way to do this, suggestions welcome!
+        features = {
+            'input_ids': torch.tensor([example[0] for example in batch], dtype=torch.long).to(self.device),
+            'attention_mask': torch.tensor([example[1] for example in batch], dtype=torch.long).to(self.device),
+        }
+        return features
+
+    def get_embeddings(
+        self,
+        token_ids,
+        attention_mask,
+        *,
+        batch_size=32,
+        normalize_embeddings=None,
+        convert_to_numpy=True,
+    ):
+        normalize_embeddings = self.normalize_embeddings if normalize_embeddings is None else normalize_embeddings
+
+        inputs = zip(token_ids, attention_mask, strict=True)
+
+        embeddings = []
+        with torch.no_grad():
+            for batch in batched(inputs, batch_size, strict=False):
+                inputs = self.turn_into_tensors(batch, self.device)
+                outputs = self.model(**inputs)
+                pooled = self.mean_pool(outputs.last_hidden_state, inputs['attention_mask'])
+                if normalize_embeddings:
+                    pooled = torch.nn.functional.normalize(pooled, p=2, dim=1)
+                embeddings.append(pooled.cpu())
+
+        embeddings = torch.cat(embeddings, dim=0)
+        if convert_to_numpy:
+            return embeddings.numpy().astype(np.float32, copy=False)
+        return embeddings

--- a/asmtransformers/asmtransformers/models/embedder.py
+++ b/asmtransformers/asmtransformers/models/embedder.py
@@ -2,6 +2,7 @@ from itertools import batched
 
 import numpy as np
 import torch
+from tqdm import tqdm
 
 from asmtransformers.models.asmbert import ASMBertModel, ASMTokenizer
 
@@ -84,7 +85,7 @@ class ASMEmbedder:
 
         embeddings = []
         with torch.no_grad():
-            for batch in batched(inputs, batch_size, strict=False):
+            for batch in tqdm(batched(inputs, batch_size, strict=False)):
                 inputs = self.turn_into_tensors(batch, self.device)
                 outputs = self.model(**inputs)
                 pooled = self.mean_pool(outputs.last_hidden_state, inputs['attention_mask'])

--- a/asmtransformers/asmtransformers/models/embedder.py
+++ b/asmtransformers/asmtransformers/models/embedder.py
@@ -70,7 +70,7 @@ class ASMEmbedder:
         }
         return features
 
-    def get_embeddings(
+    def embed(
         self,
         token_ids,
         attention_mask,

--- a/asmtransformers/asmtransformers/models/embedder.py
+++ b/asmtransformers/asmtransformers/models/embedder.py
@@ -86,7 +86,7 @@ class ASMEmbedder:
         embeddings = []
         with torch.no_grad():
             for batch in tqdm(batched(inputs, batch_size, strict=False)):
-                inputs = self.turn_into_tensors(batch, self.device)
+                inputs = self.turn_into_tensors(batch)
                 outputs = self.model(**inputs)
                 pooled = self.mean_pool(outputs.last_hidden_state, inputs['attention_mask'])
                 if normalize_embeddings:

--- a/asmtransformers/asmtransformers/models/embedder.py
+++ b/asmtransformers/asmtransformers/models/embedder.py
@@ -62,7 +62,7 @@ class ASMEmbedder:
             return embeddings.numpy().astype(np.float32, copy=False)
         return embeddings
 
-    def turn_into_tensors(self, batch, device):
+    def turn_into_tensors(self, batch):
         # there might be a smarter way to do this, suggestions welcome!
         features = {
             'input_ids': torch.tensor([example[0] for example in batch], dtype=torch.long).to(self.device),

--- a/asmtransformers/scripts/inference.py
+++ b/asmtransformers/scripts/inference.py
@@ -11,9 +11,12 @@ def main(data_folder, output_folder, model_path):
     print('Load model')
     model = ASMEmbedder.from_pretrained(model_path)
     print('Start creating embeddings')
-    embedded_functions = Dataset.from_dict(
-        {'embeddings': model.get_embeddings(eval_functions['input_ids'], eval_functions['attention_mask'])}
-    )
+    if eval_functions['input_ids']:
+        embedded_functions = Dataset.from_dict(
+            {'embeddings': model.get_embeddings(eval_functions['input_ids'], eval_functions['attention_mask'])}
+        )
+    else:
+        embedded_functions = Dataset.from_dict({'embeddings': model.encode(eval_functions['cfg'])})
     embedded_dataset = concatenate_datasets([eval_functions, embedded_functions], axis=1)
     print('Embeddings created, save to disk')
     embedded_dataset.save_to_disk(output_folder)

--- a/asmtransformers/scripts/inference.py
+++ b/asmtransformers/scripts/inference.py
@@ -11,7 +11,9 @@ def main(data_folder, output_folder, model_path):
     print('Load model')
     model = ASMEmbedder.from_pretrained(model_path)
     print('Start creating embeddings')
-    embedded_functions = Dataset.from_dict({'embeddings': model.encode(eval_functions['cfg'])})
+    embedded_functions = Dataset.from_dict(
+        {'embeddings': model.get_embeddings(eval_functions['input_ids'], eval_functions['attention_mask'])}
+    )
     embedded_dataset = concatenate_datasets([eval_functions, embedded_functions], axis=1)
     print('Embeddings created, save to disk')
     embedded_dataset.save_to_disk(output_folder)

--- a/asmtransformers/scripts/inference.py
+++ b/asmtransformers/scripts/inference.py
@@ -13,7 +13,7 @@ def main(data_folder, output_folder, model_path):
     print('Start creating embeddings')
     if eval_functions['input_ids']:
         embedded_functions = Dataset.from_dict(
-            {'embeddings': model.get_embeddings(eval_functions['input_ids'], eval_functions['attention_mask'])}
+            {'embeddings': model.embed(eval_functions['input_ids'], eval_functions['attention_mask'])}
         )
     else:
         embedded_functions = Dataset.from_dict({'embeddings': model.encode(eval_functions['cfg'])})


### PR DESCRIPTION
on testset of 400.000 functions, inference with token ids to embeddings took 12 minutes while inference with cfg to embeddings took 13 minutes. Small difference, but as we have about 20 million functions it will add up in the end