### PR TITLE
Feature/save eval pairs

### DIFF
--- a/asmtransformers/scripts/eval-datasets.py
+++ b/asmtransformers/scripts/eval-datasets.py
@@ -18,6 +18,7 @@ def get_parser() -> argparse.ArgumentParser:
 
 def main(data_folder, output_folder, pool_size, seed):
     anchor_rng = random.Random(seed)
+    neg_rng = random.Random(seed + 1)
     architectures = ['arm64', 'amd64', 'riscv64', 'i386', 'all']
     for architecture in architectures:
         print(f'creating eval data for {architecture}')
@@ -25,9 +26,7 @@ def main(data_folder, output_folder, pool_size, seed):
         anchors, positives, anchor_labels, anchor_cfgs, pos_cfgs = generate_anchor_pos_pairs(
             test_functions, anchor_rng, num_pairs=1000
         )
-        neg_pools = generate_neg_pool(
-            pool_size, test_functions, anchor_labels, anchor_cfgs, pos_cfgs, random.Random(seed + 1)
-        )
+        neg_pools = generate_neg_pool(pool_size, test_functions, anchor_labels, anchor_cfgs, pos_cfgs, neg_rng)
         Path.mkdir(Path(output_folder, architecture), parents=True, exist_ok=True)
         with Path(output_folder, architecture, 'eval_data.pkl').open('wb') as f:
             # we save only cfgs for anchors and positives; from neg_pools we are already holding only cfgs

--- a/asmtransformers/scripts/eval-datasets.py
+++ b/asmtransformers/scripts/eval-datasets.py
@@ -1,17 +1,16 @@
 import argparse
-import os
 import pickle
 import random
 from pathlib import Path
 
-from scripts.evaluation import generate_anchor_pos_pairs, generate_triplets, load_test_functions, generate_neg_pool
+from scripts.evaluation import generate_anchor_pos_pairs, generate_neg_pool, load_test_functions
 
 
 def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument('data_folder', type=str, help='folder with input data')
     parser.add_argument('output_folder', type=str, help='folder to leave output data')
-    parser.add_argument('--pool-size', type=int, help='the poolsize to pick the positive example from')
+    parser.add_argument('--pool-size', type=int, default=10000, help='the poolsize to pick the positive example from')
     parser.add_argument('--seed', type=int, default=4201, help='seed random evaluation sampling')
 
     return parser
@@ -23,12 +22,23 @@ def main(data_folder, output_folder, pool_size, seed):
     for architecture in architectures:
         print(f'creating eval data for {architecture}')
         test_functions = load_test_functions(data_folder, architecture)
-        # todo: change num_pairs = 1000 before actually using the code
-        anchors, positives, anchor_labels, anchor_cfgs, pos_cfgs = generate_anchor_pos_pairs(test_functions, anchor_rng, num_pairs=300)
-        neg_pools = generate_neg_pool(pool_size, test_functions, anchor_labels, anchor_cfgs, pos_cfgs, random.Random(seed + 1))
+        anchors, positives, anchor_labels, anchor_cfgs, pos_cfgs = generate_anchor_pos_pairs(
+            test_functions, anchor_rng, num_pairs=1000
+        )
+        neg_pools = generate_neg_pool(
+            pool_size, test_functions, anchor_labels, anchor_cfgs, pos_cfgs, random.Random(seed + 1)
+        )
         Path.mkdir(Path(output_folder, architecture), parents=True, exist_ok=True)
         with Path(output_folder, architecture, 'eval_data.pkl').open('wb') as f:
-            pickle.dump((anchors, positives, neg_pools), f)
+            # we save only cfgs for anchors and positives; from neg_pools we are already holding only cfgs
+            pickle.dump(
+                (
+                    [i['cfg'] for i in anchors],
+                    [i['cfg'] for i in positives],
+                    neg_pools
+                ),
+                f
+            )
 
 
 if __name__ == '__main__':

--- a/asmtransformers/scripts/eval-datasets.py
+++ b/asmtransformers/scripts/eval-datasets.py
@@ -31,14 +31,7 @@ def main(data_folder, output_folder, pool_size, seed):
         Path.mkdir(Path(output_folder, architecture), parents=True, exist_ok=True)
         with Path(output_folder, architecture, 'eval_data.pkl').open('wb') as f:
             # we save only cfgs for anchors and positives; from neg_pools we are already holding only cfgs
-            pickle.dump(
-                (
-                    [i['cfg'] for i in anchors],
-                    [i['cfg'] for i in positives],
-                    neg_pools
-                ),
-                f
-            )
+            pickle.dump(([i['cfg'] for i in anchors], [i['cfg'] for i in positives], neg_pools), f)
 
 
 if __name__ == '__main__':

--- a/asmtransformers/scripts/eval-datasets.py
+++ b/asmtransformers/scripts/eval-datasets.py
@@ -1,0 +1,33 @@
+import argparse
+import random
+
+from datasets import Dataset
+
+from scripts.evaluation import load_test_functions, generate_anchor_pos_pairs, generate_triplets
+
+
+def get_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument('data_folder', type=str, help='folder with input data')
+    parser.add_argument('output_folder', type=str, help='folder to leave output data')
+    parser.add_argument('--pool-size', type=int, help='the poolsize to pick the positive example from')
+    parser.add_argument('--seed', type=int, default=4201, help='seed random evaluation sampling')
+
+    return parser
+
+def main(data_folder, output_folder, pool_size, seed):
+    test_functions = load_test_functions(data_folder, architecture=None)
+    anchor_rng = random.Random(seed)
+    # todo: change num_pairs = 1000 before actually using the code
+    anchor_pairs = generate_anchor_pos_pairs(test_functions, anchor_rng, num_pairs=300)
+    test_pools = generate_triplets(
+        test_functions, anchor_pairs, pool_size=pool_size, static_pool=True, rng=seed+1
+    )
+    # todo: this does not work! find a way to save the data
+    Dataset.from_generator(test_pools)
+    Dataset.to_disk(output_folder)
+
+if __name__ == '__main__':
+    parser = get_parser()
+    args = parser.parse_args()
+    main(**vars(args))

--- a/asmtransformers/scripts/eval-datasets.py
+++ b/asmtransformers/scripts/eval-datasets.py
@@ -3,7 +3,7 @@ import random
 
 from datasets import Dataset
 
-from scripts.evaluation import load_test_functions, generate_anchor_pos_pairs, generate_triplets
+from scripts.evaluation import generate_anchor_pos_pairs, generate_triplets, load_test_functions
 
 
 def get_parser() -> argparse.ArgumentParser:
@@ -15,17 +15,17 @@ def get_parser() -> argparse.ArgumentParser:
 
     return parser
 
+
 def main(data_folder, output_folder, pool_size, seed):
     test_functions = load_test_functions(data_folder, architecture=None)
     anchor_rng = random.Random(seed)
     # todo: change num_pairs = 1000 before actually using the code
     anchor_pairs = generate_anchor_pos_pairs(test_functions, anchor_rng, num_pairs=300)
-    test_pools = generate_triplets(
-        test_functions, anchor_pairs, pool_size=pool_size, static_pool=True, rng=seed+1
-    )
+    test_pools = generate_triplets(test_functions, anchor_pairs, pool_size=pool_size, static_pool=True, rng=seed + 1)
     # todo: this does not work! find a way to save the data
     Dataset.from_generator(test_pools)
     Dataset.to_disk(output_folder)
+
 
 if __name__ == '__main__':
     parser = get_parser()

--- a/asmtransformers/scripts/eval-datasets.py
+++ b/asmtransformers/scripts/eval-datasets.py
@@ -1,9 +1,10 @@
 import argparse
+import os
+import pickle
 import random
+from pathlib import Path
 
-from datasets import Dataset
-
-from scripts.evaluation import generate_anchor_pos_pairs, generate_triplets, load_test_functions
+from scripts.evaluation import generate_anchor_pos_pairs, generate_triplets, load_test_functions, generate_neg_pool
 
 
 def get_parser() -> argparse.ArgumentParser:
@@ -17,14 +18,17 @@ def get_parser() -> argparse.ArgumentParser:
 
 
 def main(data_folder, output_folder, pool_size, seed):
-    test_functions = load_test_functions(data_folder, architecture=None)
     anchor_rng = random.Random(seed)
-    # todo: change num_pairs = 1000 before actually using the code
-    anchor_pairs = generate_anchor_pos_pairs(test_functions, anchor_rng, num_pairs=300)
-    test_pools = generate_triplets(test_functions, anchor_pairs, pool_size=pool_size, static_pool=True, rng=seed + 1)
-    # todo: this does not work! find a way to save the data
-    Dataset.from_generator(test_pools)
-    Dataset.to_disk(output_folder)
+    architectures = ['arm64', 'amd64', 'riscv64', 'i386', 'all']
+    for architecture in architectures:
+        print(f'creating eval data for {architecture}')
+        test_functions = load_test_functions(data_folder, architecture)
+        # todo: change num_pairs = 1000 before actually using the code
+        anchors, positives, anchor_labels, anchor_cfgs, pos_cfgs = generate_anchor_pos_pairs(test_functions, anchor_rng, num_pairs=300)
+        neg_pools = generate_neg_pool(pool_size, test_functions, anchor_labels, anchor_cfgs, pos_cfgs, random.Random(seed + 1))
+        Path.mkdir(Path(output_folder, architecture), parents=True, exist_ok=True)
+        with Path(output_folder, architecture, 'eval_data.pkl').open('wb') as f:
+            pickle.dump((anchors, positives, neg_pools), f)
 
 
 if __name__ == '__main__':

--- a/asmtransformers/scripts/evaluation-static-dataset.py
+++ b/asmtransformers/scripts/evaluation-static-dataset.py
@@ -28,11 +28,11 @@ def get_parser():
     parser.add_argument(
         'input_path',
         type=Path,
-        help='either the path to the test functions; or to folder containing anchor/pos/neg datasets '
-        '(one subfolder for each architecture and one generic called "all"; requires --dataset-ready flag)',
+        help='the path to folder containing anchor/pos/neg datasets '
+        '(one subfolder for each architecture and one generic called "all")',
     )
-    parser.add_argument('output_path', type=Path, help='the path to write the final scores to')
-    parser.add_argument('model_path', type=str, help='path to model')
+    parser.add_argument('output_path', type=Path, help='the path to folder where evaluation results are saved')
+    parser.add_argument('model_path', type=Path, help='path to model to be evaluated')
     return parser
 
 

--- a/asmtransformers/scripts/evaluation-static-dataset.py
+++ b/asmtransformers/scripts/evaluation-static-dataset.py
@@ -15,11 +15,11 @@ def load_triplets(data_path):
     positives = model.encode(positives)
     neg_pools = model.encode(neg_pools)
 
-    for i in range(len(anchors)):
+    for _, (anchor, positive) in enumerate(zip(anchors, positives, strict=True)):
         yield {
-            'anchor': {'embeddings': anchors[i]},
-            'pos': {'embeddings': positives[i]},
-            'negs': neg_pools,
+            'anchor': {'embeddings': anchor},
+            'pos': {'embeddings': positive},
+            'negs': [{'embeddings': neg} for neg in neg_pools],
         }
 
 
@@ -58,7 +58,8 @@ if __name__ == '__main__':
 
         # calculate mrr & accuracy
         final_mrr, final_acc = calculate_all(test_pools, output_path, output_file + f'-{architecture}')
-        results_per_architecture[architecture] = (final_mrr, final_acc)
+        results_per_architecture[f'mrr_{architecture}'] = final_mrr
+        results_per_architecture[f'acc_{architecture}'] = final_acc
 
     with Path(output_path, output_file + '-eval_per_architecture.csv').open('w') as csvfile:
         writer = csv.writer(csvfile)
@@ -80,16 +81,16 @@ if __name__ == '__main__':
         writer.writerow(
             (
                 model_name,
-                results_per_architecture['arm64'][0],
-                results_per_architecture['arm64'][1],
-                results_per_architecture['amd64'][0],
-                results_per_architecture['amd64'][1],
-                results_per_architecture['riscv64'][0],
-                results_per_architecture['riscv64'][1],
-                results_per_architecture['i386'][0],
-                results_per_architecture['i386'][1],
-                results_per_architecture['all'][0],
-                results_per_architecture['all'][1],
+                results_per_architecture['mrr_arm64'],
+                results_per_architecture['acc_arm64'],
+                results_per_architecture['mrr_amd64'],
+                results_per_architecture['acc_amd64'],
+                results_per_architecture['mrr_riscv64'],
+                results_per_architecture['acc_riscv64'],
+                results_per_architecture['mrr_i386'],
+                results_per_architecture['acc_i386'],
+                results_per_architecture['mrr_all'],
+                results_per_architecture['acc_all'],
             )
         )
 

--- a/asmtransformers/scripts/evaluation-static-dataset.py
+++ b/asmtransformers/scripts/evaluation-static-dataset.py
@@ -1,0 +1,97 @@
+import argparse
+import csv
+import pickle
+from collections import defaultdict
+from pathlib import Path
+
+from asmtransformers.models.embedder import ASMEmbedder
+from scripts.evaluation import calculate_all, timestamp
+
+
+def load_triplets(data_path):
+    with Path(data_path).open('rb') as file:
+        anchors, positives, neg_pools = pickle.load(file)
+    anchors = model.encode(anchors)
+    positives = model.encode(positives)
+    neg_pools = model.encode(neg_pools)
+
+    for i in range(len(anchors)):
+        yield {
+            'anchor': {'embeddings': anchors[i]},
+            'pos': {'embeddings': positives[i]},
+            'negs': neg_pools,
+        }
+
+
+def get_parser():
+    parser = argparse.ArgumentParser(description='evaluation')
+    parser.add_argument(
+        'input_path',
+        type=Path,
+        help='either the path to the test functions; or to folder containing anchor/pos/neg datasets '
+        '(one subfolder for each architecture and one generic called "all"; requires --dataset-ready flag)',
+    )
+    parser.add_argument('output_path', type=Path, help='the path to write the final scores to')
+    parser.add_argument('model_path', type=str, help='path to model')
+    return parser
+
+
+if __name__ == '__main__':
+    parser = get_parser()
+    args = parser.parse_args()
+
+    input_path = Path(args.input_path)
+    output_path = Path(args.output_path)
+    model_path = Path(args.model_path)
+
+    model = ASMEmbedder.from_pretrained(model_path)
+
+    model_name = model_path.parents[1].name
+    output_file = f'{timestamp()}-{model_name}'
+
+    results_per_architecture = defaultdict(int)
+    architectures = ['arm64', 'amd64', 'riscv64', 'i386', 'all']
+    for architecture in architectures:
+        print(f'evaluating {architecture}')
+        # load data and turn into usable triplets
+        test_pools = load_triplets(Path(input_path, architecture, 'eval_data.pkl'))
+
+        # calculate mrr & accuracy
+        final_mrr, final_acc = calculate_all(test_pools, output_path, output_file + f'-{architecture}')
+        results_per_architecture[architecture] = (final_mrr, final_acc)
+
+    with Path(output_path, output_file + '-eval_per_architecture.csv').open('w') as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerow(
+            (
+                'model_name',
+                'mrr_arm64',
+                'acc_arm64',
+                'mrr_amd64',
+                'acc_amd64',
+                'mrr_riscv64',
+                'acc_riscv64',
+                'mrr_i386',
+                'acc_i386',
+                'mrr_all',
+                'acc_all',
+            )
+        )
+        writer.writerow(
+            (
+                model_name,
+                results_per_architecture['arm64'][0],
+                results_per_architecture['arm64'][1],
+                results_per_architecture['amd64'][0],
+                results_per_architecture['amd64'][1],
+                results_per_architecture['riscv64'][0],
+                results_per_architecture['riscv64'][1],
+                results_per_architecture['i386'][0],
+                results_per_architecture['i386'][1],
+                results_per_architecture['all'][0],
+                results_per_architecture['all'][1],
+            )
+        )
+
+    with Path(args.output_path, output_file + '-parameters.txt').open('w') as file:
+        file.write('\n'.join(f'{key}={value!s}' for key, value in vars(args).items()))

--- a/asmtransformers/scripts/evaluation.py
+++ b/asmtransformers/scripts/evaluation.py
@@ -79,6 +79,7 @@ def generate_anchor_pos_pairs(dataset, rng, num_pairs=1000):
     anchor_labels = set()
     anchor_cfgs = set()
     pos_cfgs = set()
+    pair_cfgs = set()
     rejected = 0
 
     # If you are not evaluating on the entire data set (which we are not, because it's so big),
@@ -87,7 +88,11 @@ def generate_anchor_pos_pairs(dataset, rng, num_pairs=1000):
     # We use the entire dataset, but we generate random anchors/positves/negatives drawn from the
     # entire set instead.
 
-    while len(anchors) < num_pairs:  # Should take about an hour
+    counter = 0
+    while len(anchors) < num_pairs: # Should take about an hour
+        counter += 1
+        if counter == 100 * num_pairs:
+            print(f'{len(anchors)} pos-anchor pairs collected; {rejected} rejected; {counter} tried; possibly not enough suitable pos-anchor pairs in dataset')
         # Pick a random label
         label = rng.choice(labels)
         indexes = label2index[label]
@@ -106,9 +111,9 @@ def generate_anchor_pos_pairs(dataset, rng, num_pairs=1000):
             # same content, reject
             rejected += 1
             continue
-        if anchor['cfg'] in anchor_cfgs:
-            # this cfg has already been used as anchor
-            # it can still be used as positive for another anchor with the same label
+        if (anchor['cfg'], pos['cfg']) in pair_cfgs:
+            # we have already selected a pair that consists of these exact cfgs
+            # either by selecting these exact pairs or because the cfgs occur more often in the dataset
             rejected += 1
             continue
 
@@ -117,6 +122,7 @@ def generate_anchor_pos_pairs(dataset, rng, num_pairs=1000):
         anchor_labels.add(anchor['label'])
         anchor_cfgs.add(anchor['cfg'])
         pos_cfgs.add(pos['cfg'])
+        pair_cfgs.add((anchor['cfg'], pos['cfg']))
 
     return anchors, positives, anchor_labels, anchor_cfgs, pos_cfgs
 
@@ -221,7 +227,7 @@ def run_tests(data_folder, output_path, pool_size, static_pool, architecture, se
     print('\ngenerate test_pools\n')
     test_functions = load_test_functions(data_folder, architecture)
     anchor_rng = random.Random(seed)
-    anchor_pairs = generate_anchor_pos_pairs(test_functions, anchor_rng)
+    anchor_pairs = generate_anchor_pos_pairs(test_functions, anchor_rng, num_pairs=1000)
 
     model_name = data_folder.name
     output_file = f'{timestamp()}-{model_name}-{architecture}-{pool_size}-{static_pool}'

--- a/asmtransformers/scripts/evaluation.py
+++ b/asmtransformers/scripts/evaluation.py
@@ -94,7 +94,7 @@ def generate_anchor_pos_pairs(dataset, rng, num_pairs=1000):
         if counter == 100 * num_pairs:
             print(
                 f'{len(anchors)} pos-anchor pairs collected; {rejected} rejected; {counter} tried; '
-                f'possibly not enough suitable pos-anchor pairs in dataset'
+                f'possibly not enough suitable pos-anchor pairs in dataset; possibly stuck in loop'
             )
         # Pick a random label
         label = rng.choice(labels)
@@ -185,9 +185,9 @@ def calculate_one_rank(row):
             # Our rank is equal to the number of items that are better than us, plus one.
             return i + 1
 
-    # If we fall through the for loop without hitting the return statement,
-    # we are worse than all the negatives. Our rank is therefore
-    # equal to the number of negatives.
+    # If we reach the bottom of the loop without hitting the return statement,
+    # the positive example has a lower cosine similarity to to the anchor than all the negatives.
+    # Our rank is therefore equal to the number of negatives plus 1.
     return len(similarities) + 1
 
 

--- a/asmtransformers/scripts/evaluation.py
+++ b/asmtransformers/scripts/evaluation.py
@@ -89,10 +89,13 @@ def generate_anchor_pos_pairs(dataset, rng, num_pairs=1000):
     # entire set instead.
 
     counter = 0
-    while len(anchors) < num_pairs: # Should take about an hour
+    while len(anchors) < num_pairs:  # Should take about an hour
         counter += 1
         if counter == 100 * num_pairs:
-            print(f'{len(anchors)} pos-anchor pairs collected; {rejected} rejected; {counter} tried; possibly not enough suitable pos-anchor pairs in dataset')
+            print(
+                f'{len(anchors)} pos-anchor pairs collected; {rejected} rejected; {counter} tried; '
+                f'possibly not enough suitable pos-anchor pairs in dataset'
+            )
         # Pick a random label
         label = rng.choice(labels)
         indexes = label2index[label]

--- a/asmtransformers/scripts/evaluation.py
+++ b/asmtransformers/scripts/evaluation.py
@@ -64,7 +64,7 @@ def generate_neg_pool(pool_size, dataset, anchor_labels, anchor_cfgs, pos_cfgs, 
     return np.array(neg_embeddings)
 
 
-def generate_anchor_pos_pairs(dataset, rng):
+def generate_anchor_pos_pairs(dataset, rng, num_pairs=1000):
     """generates anchor/positive pairs while rejecting identical CFGs."""
     labels = dataset['label']
     labels_with_indices = list(enumerate(labels))
@@ -87,7 +87,7 @@ def generate_anchor_pos_pairs(dataset, rng):
     # We use the entire dataset, but we generate random anchors/positves/negatives drawn from the
     # entire set instead.
 
-    while len(anchors) < 1000:  # Should take about an hour
+    while len(anchors) < num_pairs:  # Should take about an hour
         # Pick a random label
         label = rng.choice(labels)
         indexes = label2index[label]
@@ -104,6 +104,11 @@ def generate_anchor_pos_pairs(dataset, rng):
         # This could be due to difference in compilers/ISA between x86_64 and ARM64.
         if anchor['cfg'] == pos['cfg']:
             # same content, reject
+            rejected += 1
+            continue
+        if anchor['cfg'] in anchor_cfgs:
+            # this cfg has already been used as anchor
+            # it can still be used as positive for another anchor with the same label
             rejected += 1
             continue
 

--- a/asmtransformers/scripts/evaluation.py
+++ b/asmtransformers/scripts/evaluation.py
@@ -188,7 +188,7 @@ def calculate_one_rank(row):
     # If we reach the bottom of the loop without hitting the return statement,
     # the positive example has a lower cosine similarity to the anchor than all the negatives.
     # Our rank is therefore equal to the number of negatives plus 1.
-    return len(similarities) + 1
+    return len(negs) + 1
 
 
 def calculate_all(test_pools, output_path, output_file):

--- a/asmtransformers/scripts/evaluation.py
+++ b/asmtransformers/scripts/evaluation.py
@@ -94,7 +94,7 @@ def generate_anchor_pos_pairs(dataset, rng, num_pairs=1000):
         if counter == 100 * num_pairs:
             print(
                 f'{len(anchors)} pos-anchor pairs collected; {rejected} rejected; {counter} tried; '
-                f'possibly not enough suitable pos-anchor pairs in dataset'
+                f'possibly not enough suitable pos-anchor pairs in dataset; possibly stuck in loop'
             )
         # Pick a random label
         label = rng.choice(labels)
@@ -185,9 +185,9 @@ def calculate_one_rank(row):
             # Our rank is equal to the number of items that are better than us, plus one.
             return i + 1
 
-    # If we fall through the for loop without hitting the return statement,
-    # we are worse than all the negatives. Our rank is therefore
-    # equal to the number of negatives.
+    # If we reach the bottom of the loop without hitting the return statement,
+    # the positive example has a lower cosine similarity to the anchor than all the negatives.
+    # Our rank is therefore equal to the number of negatives plus 1.
     return len(similarities) + 1
 
 

--- a/asmtransformers/scripts/evaluation.py
+++ b/asmtransformers/scripts/evaluation.py
@@ -174,7 +174,7 @@ def calculate_one_rank(row):
     # If we fall through the for loop without hitting the return statement,
     # we are worse than all the negatives. Our rank is therefore
     # equal to the number of negatives.
-    return len(similarities)
+    return len(similarities) + 1
 
 
 def calculate_all(test_pools, output_path, output_file):

--- a/asmtransformers/scripts/evaluation.py
+++ b/asmtransformers/scripts/evaluation.py
@@ -56,7 +56,7 @@ def generate_neg_pool(pool_size, dataset, anchor_labels, anchor_cfgs, pos_cfgs, 
         if neg['cfg'] in pos_cfgs:
             # same content, reject
             continue
-        neg_embeddings.append(neg['embeddings'])
+        neg_embeddings.append(neg['cfg'])
         if len(neg_embeddings) == pool_size:
             break
     if len(neg_embeddings) < pool_size:

--- a/asmtransformers/scripts/evaluation.py
+++ b/asmtransformers/scripts/evaluation.py
@@ -61,7 +61,7 @@ def generate_neg_pool(pool_size, dataset, anchor_labels, anchor_cfgs, pos_cfgs, 
             break
     if len(negs) < pool_size:
         raise ValueError(f'only {len(negs)} eligible negative examples available for pool_size={pool_size}')
-    return negs  # np.array(negs)
+    return negs
 
 
 def generate_anchor_pos_pairs(dataset, rng, num_pairs=1000):
@@ -175,7 +175,7 @@ def calculate_one_rank(row):
     anchor, pos, negs = (
         row['anchor']['embeddings'],
         row['pos']['embeddings'],
-        np.array([i['embeddings'] for i in row['negs']]),
+        np.array([neg['embeddings'] for neg in row['negs']]),
     )
 
     # calculate the cosine distance between the anchor and pos

--- a/asmtransformers/scripts/evaluation.py
+++ b/asmtransformers/scripts/evaluation.py
@@ -155,7 +155,8 @@ def generate_triplets(dataset, anchor_pairs, pool_size, static_pool, rng):
 
 def load_test_functions(data_folder, architecture=None):
     dataset = datasets.load_from_disk(data_folder)  # .select(range(11000, 45000))
-    if architecture:
+    # if we want to evaluate all architectures, we do not need to filter the data
+    if architecture != 'all':
         print(f'Selecting examples with architecture=={architecture}')
         dataset = dataset.filter(lambda x: x['architecture'] == architecture)
 
@@ -223,14 +224,11 @@ def run_tests(data_folder, output_path, pool_size, static_pool, architecture, se
         raise ValueError('repeats must be at least 1')
     if repeats > 1 and not static_pool:
         raise ValueError('repeats greater than 1 are only supported with --static-pool')
-    # architecture is a filter; if we want to evaluate all architectures at once, we do not filer the dataset
-    if architecture == 'all':
-        architecture = None
 
     print('\ngenerate test_pools\n')
     test_functions = load_test_functions(data_folder, architecture)
     anchor_rng = random.Random(seed)
-    anchor_pairs = generate_anchor_pos_pairs(test_functions, anchor_rng, num_pairs=1000)
+    anchor_pairs = generate_anchor_pos_pairs(test_functions, anchor_rng, num_pairs=300)
 
     model_name = data_folder.name
     output_file = f'{timestamp()}-{model_name}-{architecture}-{pool_size}-{static_pool}'
@@ -264,7 +262,7 @@ def run_tests(data_folder, output_path, pool_size, static_pool, architecture, se
 
 def get_parser():
     parser = argparse.ArgumentParser(description='evaluation')
-    parser.add_argument('input_path', type=Path, help='the path to the test data')
+    parser.add_argument('input_path', type=Path, help='the path to the anchors/positives/negative pools')
     parser.add_argument('output_path', type=Path, help='the path to write the final scores to')
     parser.add_argument('--pool-size', type=int, help='the poolsize to pick the positive example from')
     parser.add_argument('--seed', type=int, default=4201, help='seed random evaluation sampling')

--- a/asmtransformers/scripts/evaluation.py
+++ b/asmtransformers/scripts/evaluation.py
@@ -42,7 +42,7 @@ def generate_neg_pool(pool_size, dataset, anchor_labels, anchor_cfgs, pos_cfgs, 
     :param rng: random number generator
     :return: a numpy array containing the embeddings of the items in the pool
     """
-    neg_embeddings = []
+    negs = []
     candidate_indices = list(range(len(dataset)))
     rng.shuffle(candidate_indices)
     for index in candidate_indices:
@@ -56,12 +56,12 @@ def generate_neg_pool(pool_size, dataset, anchor_labels, anchor_cfgs, pos_cfgs, 
         if neg['cfg'] in pos_cfgs:
             # same content, reject
             continue
-        neg_embeddings.append(neg['cfg'])
-        if len(neg_embeddings) == pool_size:
+        negs.append(neg)
+        if len(negs) == pool_size:
             break
-    if len(neg_embeddings) < pool_size:
-        raise ValueError(f'only {len(neg_embeddings)} eligible negative examples available for pool_size={pool_size}')
-    return np.array(neg_embeddings)
+    if len(negs) < pool_size:
+        raise ValueError(f'only {len(negs)} eligible negative examples available for pool_size={pool_size}')
+    return negs  # np.array(negs)
 
 
 def generate_anchor_pos_pairs(dataset, rng, num_pairs=1000):
@@ -172,7 +172,11 @@ def calculate_one_rank(row):
     :param row: anchor, pos, and list of negs
     :return The rank of the positive example (pos) in the pool.
     """
-    anchor, pos, negs = row['anchor']['embeddings'], row['pos']['embeddings'], row['negs']
+    anchor, pos, negs = (
+        row['anchor']['embeddings'],
+        row['pos']['embeddings'],
+        np.array([i['embeddings'] for i in row['negs']]),
+    )
 
     # calculate the cosine distance between the anchor and pos
     cosine_sim_pos = 1 - spatial.distance.cosine(anchor, pos)
@@ -228,7 +232,7 @@ def run_tests(data_folder, output_path, pool_size, static_pool, architecture, se
     print('\ngenerate test_pools\n')
     test_functions = load_test_functions(data_folder, architecture)
     anchor_rng = random.Random(seed)
-    anchor_pairs = generate_anchor_pos_pairs(test_functions, anchor_rng, num_pairs=300)
+    anchor_pairs = generate_anchor_pos_pairs(test_functions, anchor_rng, num_pairs=30)
 
     model_name = data_folder.name
     output_file = f'{timestamp()}-{model_name}-{architecture}-{pool_size}-{static_pool}'

--- a/asmtransformers/tests/test_evaluation.py
+++ b/asmtransformers/tests/test_evaluation.py
@@ -1,0 +1,39 @@
+import numpy as np
+import pytest
+
+from scripts import evaluation
+from scripts.evaluation import (
+    calculate_all,
+    calculate_one_rank,
+    generate_triplets,
+    generate_anchor_pos_pairs,
+    generate_neg_pool
+)
+
+@pytest.fixture
+def rank1():
+    return {'anchor':{'embeddings':[0, 1, 2]},
+           'pos': {'embeddings':[1, 2, 3]},
+           'negs':np.array([[4, 5, 6], [7, 8, 9]])}
+
+@pytest.fixture
+def rank2():
+    return {'anchor': {'embeddings': [0, 1, 2]},
+         'pos': {'embeddings': [4, 5, 6]},
+         'negs': np.array([[7, 8, 9], [1, 2, 3]])}
+
+def test_calculate_one_rank(rank1, rank2):
+    assert calculate_one_rank(rank1) == 1
+    assert calculate_one_rank(rank2) == 2
+
+
+def test_calculate_all(rank1, rank2, tmp_path):
+    # both ranked first
+    test_pools = [rank1, rank1]
+    assert calculate_all(test_pools, tmp_path, 'test_calculate_all.csv') == (1, 1)
+    # one ranked first, one ranked second
+    test_pools = [rank1, rank2]
+    assert calculate_all(test_pools, tmp_path, 'test_calculate_all.csv') == (0.75, 1/2)
+    # both ranked second place
+    test_pools = [rank2, rank2]
+    assert calculate_all(test_pools, tmp_path, 'test_calculate_all.csv') == (0.5, 0)

--- a/asmtransformers/tests/test_evaluation.py
+++ b/asmtransformers/tests/test_evaluation.py
@@ -22,9 +22,16 @@ def rank2():
          'pos': {'embeddings': [4, 5, 6]},
          'negs': np.array([[7, 8, 9], [1, 2, 3]])}
 
-def test_calculate_one_rank(rank1, rank2):
+@pytest.fixture
+def rank3():
+    return {'anchor': {'embeddings': [0, 1, 2]},
+            'pos': {'embeddings': [7, 8, 9]},
+            'negs': np.array([[4, 5, 6], [1, 2, 3]])}
+
+def test_calculate_one_rank(rank1, rank2, rank3):
     assert calculate_one_rank(rank1) == 1
     assert calculate_one_rank(rank2) == 2
+    assert calculate_one_rank(rank3) == 3
 
 
 def test_calculate_all(rank1, rank2, tmp_path):

--- a/asmtransformers/tests/test_evaluation.py
+++ b/asmtransformers/tests/test_evaluation.py
@@ -9,6 +9,7 @@ from scripts.evaluation import calculate_all, calculate_one_rank, generate_ancho
 
 @pytest.fixture
 def rank1():
+    # pos [1, 2, 3] is closer to anchor [0, 1, 2] than negs, therefore it is ranked 1
     return {
         'anchor': {'embeddings': [0, 1, 2]},
         'pos': {'embeddings': [1, 2, 3]},
@@ -18,6 +19,8 @@ def rank1():
 
 @pytest.fixture
 def rank2():
+    # pos [4, 5, 6] is closer to anchor [0, 1, 2] than [7, 8, 9], but further than [1, 2, 3]
+    # therefore the positive is ranked 2nd
     return {
         'anchor': {'embeddings': [0, 1, 2]},
         'pos': {'embeddings': [4, 5, 6]},
@@ -26,6 +29,7 @@ def rank2():
 
 
 @pytest.fixture
+    # pos [7, 8, 9] is further away from anchor [0, 1, 2] than both negs, and is therefore ranked 3rd/last
 def rank3():
     return {
         'anchor': {'embeddings': [0, 1, 2]},

--- a/asmtransformers/tests/test_evaluation.py
+++ b/asmtransformers/tests/test_evaluation.py
@@ -29,7 +29,7 @@ def rank2():
 
 
 @pytest.fixture
-    # pos [7, 8, 9] is further away from anchor [0, 1, 2] than both negs, and is therefore ranked 3rd/last
+# pos [7, 8, 9] is further away from anchor [0, 1, 2] than both negs, and is therefore ranked 3rd/last
 def rank3():
     return {
         'anchor': {'embeddings': [0, 1, 2]},
@@ -47,13 +47,13 @@ def test_calculate_one_rank(rank1, rank2, rank3):
 def test_calculate_all(rank1, rank2, tmp_path):
     # both ranked first
     test_pools = [rank1, rank1]
-    assert calculate_all(test_pools, tmp_path, 'test_calculate_all.csv') == (1, 1)
+    assert calculate_all(test_pools, tmp_path, 'test_calculate_all_1.csv') == (1, 1)
     # one ranked first, one ranked second
     test_pools = [rank1, rank2]
-    assert calculate_all(test_pools, tmp_path, 'test_calculate_all.csv') == (0.75, 1 / 2)
+    assert calculate_all(test_pools, tmp_path, 'test_calculate_all_0_75.csv') == (0.75, 1 / 2)
     # both ranked second place
     test_pools = [rank2, rank2]
-    assert calculate_all(test_pools, tmp_path, 'test_calculate_all.csv') == (0.5, 0)
+    assert calculate_all(test_pools, tmp_path, 'test_calculate_all_0_5.csv') == (0.5, 0)
 
 
 @pytest.fixture
@@ -62,15 +62,16 @@ def dataset():
     return Dataset.from_dict(
         {
             'label': ['return', 'return', 'jump', 'jump', 'move', 'move', 'add', 'add'],
+            # these are not full cfgs, but single instructions. this is a simplification for testing's sake
             'cfg': [
-                'ret',
-                'ret',
-                'j 0x32',
-                'c.j 0x02',
-                'c.mv a3,a5',
-                'c.mv s8,a5',
-                'c.addi4spn s0,sp,0x30',
-                'addi a5,s0,-0xb0',
+                '[[0, [ret]]]',
+                '[[0, [ret]]]',
+                '[[1, [j 0x32]]]',
+                '[[2, [c.j 0x02]]]',
+                '[[3, [c.mv a3,a5]]]',
+                '[[4, [c.mv s8,a5]]]',
+                '[[5, [c.addi4spn s0,sp,0x30]]]',
+                '[[6, [addi a5,s0,-0xb0]]]',
             ],
         }
     )
@@ -90,7 +91,7 @@ def pos_anchor_pairs(dataset, rng):
 def test_generate_anchor_pos_pairs(pos_anchor_pairs):
     anchors, positives, _, _, _ = pos_anchor_pairs
     assert len(anchors) == 3
-    assert anchors[0] == {'label': 'add', 'cfg': 'addi a5,s0,-0xb0'}
+    assert anchors[0] == {'label': 'add', 'cfg': '[[6, [addi a5,s0,-0xb0]]]'}
     # make sure the anchors and positives of the same pair have the same index
     assert anchors[0]['label'] == 'add' and positives[0]['label'] == 'add'
     # assert pairs are always in the same order (this is more for continuity than for passing the test right now)
@@ -102,13 +103,15 @@ def dataset_extended():
     return Dataset.from_dict(
         {
             'label': ['a', 'b', 'c', 'd', 'e', 'jump'],
+            # these are not full cfgs, but single instructions. this is a simplification for testing's sake
             'cfg': [
-                'rax, rbx',
-                'rsp,-0x10',
-                '[rbp+-0x8]',
-                'dword ptr [rbp + -0x8]',
-                'xmmword   ptr [rax]',
-                'j 0x32',  # this one will be rejected based on label & cfgs being part of the anchor pos pairs
+                '[[7, [rax, rbx]]]',
+                '[[8, [rsp,-0x10]]]',
+                '[[9, [rbp+-0x8]]]',
+                '[[10, [dword ptr [rbp + -0x8]]]]',
+                '[[11, [xmmword ptr [rax]]]]',
+                # this one will be rejected based on label & cfgs being part of the anchor pos pairs
+                '[[12, [j 0x32]]]',
             ],
             'embeddings': [1, 2, 3, 4, 5, 6],
         }

--- a/asmtransformers/tests/test_evaluation.py
+++ b/asmtransformers/tests/test_evaluation.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 from datasets import Dataset
 
-from scripts.evaluation import calculate_all, calculate_one_rank, generate_anchor_pos_pairs
+from scripts.evaluation import calculate_all, calculate_one_rank, generate_anchor_pos_pairs, generate_neg_pool
 
 
 @pytest.fixture
@@ -77,13 +77,45 @@ def rng():
     return random.Random(10)
 
 
-def test_generate_anchor_pos_pairs(dataset, rng):
+@pytest.fixture
+def pos_anchor_pairs(dataset, rng):
     anchors, positives, anchor_labels, anchor_cfgs, pos_cfgs = generate_anchor_pos_pairs(dataset, rng, num_pairs=3)
-    print(anchors)
-    print(positives)
+    return anchors, positives, anchor_labels, anchor_cfgs, pos_cfgs
+
+
+def test_generate_anchor_pos_pairs(pos_anchor_pairs):
+    anchors, positives, _, _, _ = pos_anchor_pairs
     assert len(anchors) == 3
     assert anchors[0] == {'label': 'add', 'cfg': 'addi a5,s0,-0xb0'}
     # make sure the anchors and positives of the same pair have the same index
     assert anchors[0]['label'] == 'add' and positives[0]['label'] == 'add'
     # assert pairs are always in the same order (this is more for continuity than for passing the test right now)
     assert anchors[0]['label'] == 'add' and anchors[1]['label'] == 'move' and anchors[2]['label'] == 'jump'
+
+
+@pytest.fixture
+def dataset_extended():
+    return Dataset.from_dict(
+        {
+            'label': ['a', 'b', 'c', 'd', 'e', 'jump'],
+            'cfg': [
+                'rax, rbx',
+                'rsp,-0x10',
+                '[rbp+-0x8]',
+                'dword ptr [rbp + -0x8]',
+                'xmmword   ptr [rax]',
+                'j 0x32',  # this one will be rejected based on label & cfgs being part of the anchor pos pairs
+            ],
+            'embeddings': [1, 2, 3, 4, 5, 6],
+        }
+    )
+
+
+def test_generate_neg_pool(pos_anchor_pairs, dataset_extended, rng):
+    _, _, anchor_labels, anchor_cfgs, pos_cfgs = pos_anchor_pairs
+    # we can't request for a pool size 6, because there are only 5 valid negatives in dataset_extended
+    with pytest.raises(ValueError):
+        generate_neg_pool(6, dataset_extended, anchor_labels, anchor_cfgs, pos_cfgs, rng)
+    neg_embeddings = generate_neg_pool(5, dataset_extended, anchor_labels, anchor_cfgs, pos_cfgs, rng)
+    # once again we check that neg embeddings are always in the same order
+    assert neg_embeddings[0] == 2 and neg_embeddings[1] == 3 and neg_embeddings[-1] == 1

--- a/asmtransformers/tests/test_evaluation.py
+++ b/asmtransformers/tests/test_evaluation.py
@@ -111,7 +111,7 @@ def dataset_extended():
                 '[[10, [dword ptr [rbp + -0x8]]]]',
                 '[[11, [xmmword ptr [rax]]]]',
                 # this one will be rejected based on label & cfgs being part of the anchor pos pairs
-                '[[12, [j 0x32]]]',
+                '[[1, [j 0x32]]]',
             ],
             'embeddings': [1, 2, 3, 4, 5, 6],
         }
@@ -126,3 +126,4 @@ def test_generate_neg_pool(pos_anchor_pairs, dataset_extended, rng):
     neg_embeddings = generate_neg_pool(5, dataset_extended, anchor_labels, anchor_cfgs, pos_cfgs, rng)
     # once again we check that neg embeddings are always in the same order
     assert neg_embeddings[0] == 2 and neg_embeddings[1] == 3 and neg_embeddings[-1] == 1
+    assert 6 not in neg_embeddings

--- a/asmtransformers/tests/test_evaluation.py
+++ b/asmtransformers/tests/test_evaluation.py
@@ -4,31 +4,35 @@ import numpy as np
 import pytest
 from datasets import Dataset
 
-from scripts import evaluation
-from scripts.evaluation import (
-    calculate_all,
-    calculate_one_rank,
-    generate_anchor_pos_pairs,
-    generate_neg_pool
-)
+from scripts.evaluation import calculate_all, calculate_one_rank, generate_anchor_pos_pairs
+
 
 @pytest.fixture
 def rank1():
-    return {'anchor':{'embeddings':[0, 1, 2]},
-           'pos': {'embeddings':[1, 2, 3]},
-           'negs':np.array([[4, 5, 6], [7, 8, 9]])}
+    return {
+        'anchor': {'embeddings': [0, 1, 2]},
+        'pos': {'embeddings': [1, 2, 3]},
+        'negs': np.array([[4, 5, 6], [7, 8, 9]]),
+    }
+
 
 @pytest.fixture
 def rank2():
-    return {'anchor': {'embeddings': [0, 1, 2]},
-         'pos': {'embeddings': [4, 5, 6]},
-         'negs': np.array([[7, 8, 9], [1, 2, 3]])}
+    return {
+        'anchor': {'embeddings': [0, 1, 2]},
+        'pos': {'embeddings': [4, 5, 6]},
+        'negs': np.array([[7, 8, 9], [1, 2, 3]]),
+    }
+
 
 @pytest.fixture
 def rank3():
-    return {'anchor': {'embeddings': [0, 1, 2]},
-            'pos': {'embeddings': [7, 8, 9]},
-            'negs': np.array([[4, 5, 6], [1, 2, 3]])}
+    return {
+        'anchor': {'embeddings': [0, 1, 2]},
+        'pos': {'embeddings': [7, 8, 9]},
+        'negs': np.array([[4, 5, 6], [1, 2, 3]]),
+    }
+
 
 def test_calculate_one_rank(rank1, rank2, rank3):
     assert calculate_one_rank(rank1) == 1
@@ -42,7 +46,7 @@ def test_calculate_all(rank1, rank2, tmp_path):
     assert calculate_all(test_pools, tmp_path, 'test_calculate_all.csv') == (1, 1)
     # one ranked first, one ranked second
     test_pools = [rank1, rank2]
-    assert calculate_all(test_pools, tmp_path, 'test_calculate_all.csv') == (0.75, 1/2)
+    assert calculate_all(test_pools, tmp_path, 'test_calculate_all.csv') == (0.75, 1 / 2)
     # both ranked second place
     test_pools = [rank2, rank2]
     assert calculate_all(test_pools, tmp_path, 'test_calculate_all.csv') == (0.5, 0)
@@ -51,16 +55,22 @@ def test_calculate_all(rank1, rank2, tmp_path):
 @pytest.fixture
 def dataset():
     # same label means potential pair
-    return Dataset.from_dict({'label' : ['return', 'return', 'jump', 'jump', 'move', 'move', 'add', 'add'],
-            'cfg': ['ret',
-                    'ret',
-                    'j 0x32',
-                    'c.j 0x02',
-                    'c.mv a3,a5',
-                    'c.mv s8,a5',
-                    'c.addi4spn s0,sp,0x30',
-                    'addi a5,s0,-0xb0'
-                    ]})
+    return Dataset.from_dict(
+        {
+            'label': ['return', 'return', 'jump', 'jump', 'move', 'move', 'add', 'add'],
+            'cfg': [
+                'ret',
+                'ret',
+                'j 0x32',
+                'c.j 0x02',
+                'c.mv a3,a5',
+                'c.mv s8,a5',
+                'c.addi4spn s0,sp,0x30',
+                'addi a5,s0,-0xb0',
+            ],
+        }
+    )
+
 
 @pytest.fixture
 def rng():

--- a/asmtransformers/tests/test_evaluation.py
+++ b/asmtransformers/tests/test_evaluation.py
@@ -1,11 +1,13 @@
+import random
+
 import numpy as np
 import pytest
+from datasets import Dataset
 
 from scripts import evaluation
 from scripts.evaluation import (
     calculate_all,
     calculate_one_rank,
-    generate_triplets,
     generate_anchor_pos_pairs,
     generate_neg_pool
 )
@@ -44,3 +46,34 @@ def test_calculate_all(rank1, rank2, tmp_path):
     # both ranked second place
     test_pools = [rank2, rank2]
     assert calculate_all(test_pools, tmp_path, 'test_calculate_all.csv') == (0.5, 0)
+
+
+@pytest.fixture
+def dataset():
+    # same label means potential pair
+    return Dataset.from_dict({'label' : ['return', 'return', 'jump', 'jump', 'move', 'move', 'add', 'add'],
+            'cfg': ['ret',
+                    'ret',
+                    'j 0x32',
+                    'c.j 0x02',
+                    'c.mv a3,a5',
+                    'c.mv s8,a5',
+                    'c.addi4spn s0,sp,0x30',
+                    'addi a5,s0,-0xb0'
+                    ]})
+
+@pytest.fixture
+def rng():
+    return random.Random(10)
+
+
+def test_generate_anchor_pos_pairs(dataset, rng):
+    anchors, positives, anchor_labels, anchor_cfgs, pos_cfgs = generate_anchor_pos_pairs(dataset, rng, num_pairs=3)
+    print(anchors)
+    print(positives)
+    assert len(anchors) == 3
+    assert anchors[0] == {'label': 'add', 'cfg': 'addi a5,s0,-0xb0'}
+    # make sure the anchors and positives of the same pair have the same index
+    assert anchors[0]['label'] == 'add' and positives[0]['label'] == 'add'
+    # assert pairs are always in the same order (this is more for continuity than for passing the test right now)
+    assert anchors[0]['label'] == 'add' and anchors[1]['label'] == 'move' and anchors[2]['label'] == 'jump'

--- a/asmtransformers/tests/test_evaluation.py
+++ b/asmtransformers/tests/test_evaluation.py
@@ -125,5 +125,9 @@ def test_generate_neg_pool(pos_anchor_pairs, dataset_extended, rng):
         generate_neg_pool(6, dataset_extended, anchor_labels, anchor_cfgs, pos_cfgs, rng)
     neg_embeddings = generate_neg_pool(5, dataset_extended, anchor_labels, anchor_cfgs, pos_cfgs, rng)
     # once again we check that neg embeddings are always in the same order
-    assert neg_embeddings[0] == 2 and neg_embeddings[1] == 3 and neg_embeddings[-1] == 1
+    assert (
+        neg_embeddings[0]['embeddings'] == 2
+        and neg_embeddings[1]['embeddings'] == 3
+        and neg_embeddings[-1]['embeddings'] == 1
+    )
     assert 6 not in neg_embeddings

--- a/asmtransformers/tests/test_evaluation.py
+++ b/asmtransformers/tests/test_evaluation.py
@@ -13,7 +13,7 @@ def rank1():
     return {
         'anchor': {'embeddings': [0, 1, 2]},
         'pos': {'embeddings': [1, 2, 3]},
-        'negs': np.array([[4, 5, 6], [7, 8, 9]]),
+        'negs': [{'embeddings': np.array([4, 5, 6])}, {'embeddings': np.array([7, 8, 9])}],
     }
 
 
@@ -24,7 +24,7 @@ def rank2():
     return {
         'anchor': {'embeddings': [0, 1, 2]},
         'pos': {'embeddings': [4, 5, 6]},
-        'negs': np.array([[7, 8, 9], [1, 2, 3]]),
+        'negs': [{'embeddings': np.array([7, 8, 9])}, {'embeddings': np.array([1, 2, 3])}],
     }
 
 
@@ -34,7 +34,7 @@ def rank3():
     return {
         'anchor': {'embeddings': [0, 1, 2]},
         'pos': {'embeddings': [7, 8, 9]},
-        'negs': np.array([[4, 5, 6], [1, 2, 3]]),
+        'negs': [{'embeddings': np.array([4, 5, 6])}, {'embeddings': np.array([1, 2, 3])}],
     }
 
 


### PR DESCRIPTION
This probably should have been two PRs:
1. testing for evaluation.py, which is almost all code in evaluation.py and test_evaluation.py
2. creating separate scripts in order to:
        - save the anchor-pos-negative pairs WITHOUT their embeddings
        - embed this previously saved dataset using a given model
        - evaluate that given model
    this all happens in eval-dataset.py and evaluate-static-dataset.py