### PR TITLE
Expose auth configuration from REST

### DIFF
--- a/citatio/citatio/api.py
+++ b/citatio/citatio/api.py
@@ -100,7 +100,7 @@ def identify_user(
 app = FastAPI(lifespan=lifespan)
 
 
-@app.get('/api/v1/auth')
+@app.get('/api/v1/auth/configuration')
 async def auth_config(request: Request):
     # collect enabled authentication modes as booleans
     auth = {mode: mode in request.app.state.identification_modes for mode in SUPPORTED_AUTH_MODES}

--- a/citatio/citatio/api.py
+++ b/citatio/citatio/api.py
@@ -58,7 +58,7 @@ async def connect_database(**connect) -> Database:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    config = confidence.load_name('citatio')
+    app.state.config = config = confidence.load_name('citatio')
 
     app.state.model = load_model(config.model or DEFAULT_MODEL)
 
@@ -98,6 +98,22 @@ def identify_user(
 
 
 app = FastAPI(lifespan=lifespan)
+
+
+@app.get('/api/v1/auth')
+async def auth_config(request: Request):
+    # collect enabled authentication modes as booleans
+    auth = {mode: mode in request.app.state.identification_modes for mode in SUPPORTED_AUTH_MODES}
+    if auth['oidc']:
+        # replace true with actionable config for oidc
+        oidc = request.app.state.config.auth.oidc
+        auth['oidc'] = {
+            'client_id': oidc.client_id,
+            'provider_uri': oidc.base_authorization_server_uri,
+            'issuer': oidc.issuer,
+        }
+
+    return auth
 
 
 @app.post('/api/v1/functions')

--- a/citatio/tests/test_api.py
+++ b/citatio/tests/test_api.py
@@ -70,6 +70,8 @@ def test_add_function_anonymous_not_allowed(monkeypatch, client, functions):
     monkeypatch.setattr(app.state, 'identification_modes', {'client_supplied'})
     response = client.post('/api/v1/functions', json=functions[0])
     assert response.status_code == 401
+    response = client.post('/api/v1/functions', json={**functions[1], 'user_id': 'MiniDane'})
+    assert response.status_code == 200
 
 
 def test_search_known(client, functions):

--- a/citatio/tests/test_api.py
+++ b/citatio/tests/test_api.py
@@ -16,6 +16,38 @@ async def client(monkeypatch, database_env):
         yield client
 
 
+def test_get_auth_config(client):
+    response = client.get('/api/v1/auth')
+    assert response.status_code == 200
+    assert response.json() == {'anonymous': True, 'client_supplied': True, 'oidc': False}
+
+
+def test_get_auth_config_oidc(monkeypatch, database_env):
+    monkeypatch.setenv('CITATIO_MODEL', '":test:"')
+    # disable the silly auth
+    monkeypatch.setenv('CITATIO_AUTH_ANONYMOUS', 'false')
+    monkeypatch.setenv('CITATIO_AUTH_CLIENT__SUPPLIED', 'false')
+    # configure an OIDC provider at example.com
+    monkeypatch.setenv('CITATIO_AUTH_OIDC_CLIENT__ID', 'Cl1eNt-1D')
+    monkeypatch.setenv('CITATIO_AUTH_OIDC_BASE__AUTHORIZATION__SERVER__URI', 'https://example.com/auth')
+    monkeypatch.setenv('CITATIO_AUTH_OIDC_ISSUER', 'example.com')
+    # cache ttl is required, but omitted from the response content
+    monkeypatch.setenv('CITATIO_AUTH_OIDC_SIGNATURE__CACHE__TTL', '3600')
+
+    with TestClient(app) as client:
+        response = client.get('/api/v1/auth')
+        assert response.status_code == 200
+        assert response.json() == {
+            'anonymous': False,
+            'client_supplied': False,
+            'oidc': {
+                'client_id': 'Cl1eNt-1D',
+                'provider_uri': 'https://example.com/auth',
+                'issuer': 'example.com',
+            },
+        }
+
+
 def test_no_auth(client, functions):
     response = client.post('/api/v1/functions', headers={'Authorization': 'Bearer R1ghtT0B34r4RMs'}, json=functions[0])
     assert response.is_server_error

--- a/citatio/tests/test_api.py
+++ b/citatio/tests/test_api.py
@@ -17,7 +17,7 @@ async def client(monkeypatch, database_env):
 
 
 def test_get_auth_config(client):
-    response = client.get('/api/v1/auth')
+    response = client.get('/api/v1/auth/configuration')
     assert response.status_code == 200
     assert response.json() == {'anonymous': True, 'client_supplied': True, 'oidc': False}
 
@@ -35,7 +35,7 @@ def test_get_auth_config_oidc(monkeypatch, database_env):
     monkeypatch.setenv('CITATIO_AUTH_OIDC_SIGNATURE__CACHE__TTL', '3600')
 
     with TestClient(app) as client:
-        response = client.get('/api/v1/auth')
+        response = client.get('/api/v1/auth/configuration')
         assert response.status_code == 200
         assert response.json() == {
             'anonymous': False,


### PR DESCRIPTION
At least the configured base url is needed by the client to go figure out where to get a token from. The client id might aid in finding the right configuration at `base_url/.well-known/oidc-configuration/`.