### PR TITLE
Let Sententia use the new rest paths

### DIFF
--- a/sententia/src/main/java/nl/nfi/sententia/FunctionDescriptor.java
+++ b/sententia/src/main/java/nl/nfi/sententia/FunctionDescriptor.java
@@ -9,30 +9,36 @@ import ghidra.util.exception.CancelledException;
 import ghidra.util.exception.InvalidInputException;
 
 
-
 public class FunctionDescriptor {
 	public String name;
 	public String binaryName;
 	List<List<Object>> functionCFG;
+	public String architecture;
 	public String binarySHA256;
 	
 	public FunctionDescriptor(Function function) throws InvalidInputException, CancelledException {
-		this(function.getName(), SententiaUtil.getFunctionCFG(function), function.getProgram().getName(), function.getProgram().getExecutableSHA256());
+		this(
+		    function.getName(),
+		    SententiaUtil.getFunctionCFG(function),
+		    function.getProgram().getName(),
+		    SententiaUtil.toArchitecture(function.getProgram().getLanguageID()),
+		    function.getProgram().getExecutableSHA256()
+        );
 	}
-	
-	
-	public FunctionDescriptor(String functionName, List<List<Object>> functionCFG, String binaryName, String binarySHA256) {
+
+	public FunctionDescriptor(String functionName, List<List<Object>> functionCFG, String architecture, String binaryName, String binarySHA256) {
 		this.name = functionName;
 		this.functionCFG = functionCFG;
+		this.architecture = architecture;
 		this.binaryName = binaryName;
 		this.binarySHA256 = binarySHA256;
 	}
-	
+
 	public JSONObject toJson() {
 		JSONObject jsonFunctionDescriptor = new JSONObject();
 		jsonFunctionDescriptor.put("name", this.name);
-		
 		jsonFunctionDescriptor.put("cfg", this.functionCFG);
+		jsonFunctionDescriptor.put("architecture", this.architecture);
 		jsonFunctionDescriptor.put("binary_name", this.binaryName);
 		jsonFunctionDescriptor.put("binary_sha256", this.binarySHA256);
 		return jsonFunctionDescriptor;

--- a/sententia/src/main/java/nl/nfi/sententia/FunctionDescriptor.java
+++ b/sententia/src/main/java/nl/nfi/sententia/FunctionDescriptor.java
@@ -36,7 +36,7 @@ public class FunctionDescriptor {
 
 	public JSONObject toJson() {
 		JSONObject jsonFunctionDescriptor = new JSONObject();
-		jsonFunctionDescriptor.put("name", this.name);
+		jsonFunctionDescriptor.put("label", this.name);
 		jsonFunctionDescriptor.put("cfg", this.functionCFG);
 		jsonFunctionDescriptor.put("architecture", this.architecture);
 		jsonFunctionDescriptor.put("binary_name", this.binaryName);

--- a/sententia/src/main/java/nl/nfi/sententia/SententiaAPI.java
+++ b/sententia/src/main/java/nl/nfi/sententia/SententiaAPI.java
@@ -45,7 +45,7 @@ public class SententiaAPI {
         ArrayList<SententiaResult> results = new ArrayList<>();
         
         // Construct the full URL
-        URI targetURI = new URI(this.serverURL.toString() + API_URL + "/search");
+        URI targetURI = new URI(this.serverURL.toString() + API_URL + "/functions/search");
 
         // Prepare the JSON payload
         String jsonPayload = descriptor.toJson().toJSONString();
@@ -67,9 +67,9 @@ public class SententiaAPI {
         // Process the response
         for (Object result : jsonResponse) {
             JSONObject jsonResult = (JSONObject) result;
-            if (jsonResult.get("function") instanceof String && jsonResult.get("similarity") instanceof Double) {
+            if (jsonResult.get("label") instanceof String && jsonResult.get("similarity") instanceof Double) {
                 results.add(new SententiaResult(
-                    (String) jsonResult.get("function"),
+                    (String) jsonResult.get("label"),
                     (Double) jsonResult.get("similarity")
                 ));
             } else {
@@ -85,7 +85,7 @@ public class SententiaAPI {
     }
 
     public void addSignatureToDB(FunctionDescriptor descriptor) throws IOException, URISyntaxException, InterruptedException {
-        URI targetURI = new URI(serverURL.toString() + API_URL + "/add");
+        URI targetURI = new URI(serverURL.toString() + API_URL + "/functions");
 
         // Prepare the JSON payload
         String jsonPayload = descriptor.toJson().toJSONString();

--- a/sententia/src/main/java/nl/nfi/sententia/SententiaUtil.java
+++ b/sententia/src/main/java/nl/nfi/sententia/SententiaUtil.java
@@ -8,6 +8,7 @@ import ghidra.program.model.address.AddressRangeIterator;
 import ghidra.program.model.address.AddressSet;
 import ghidra.program.model.block.CodeBlock;
 import ghidra.program.model.block.SimpleBlockModel;
+import ghidra.program.model.lang.LanguageID;
 import ghidra.program.model.listing.CodeUnit;
 import ghidra.program.model.listing.Function;
 import ghidra.util.exception.CancelledException;
@@ -41,5 +42,10 @@ public class SententiaUtil {
 		}
 		
 		return functionCFG;
+	}
+
+	public static String toArchitecture(LanguageID languageId) {
+	    // TODO: translate languageId (e.g. x86:LE:32:default) to one of (amd64, arm64, i386, riscv64)
+        return languageId.getIdAsString();
 	}
 }


### PR DESCRIPTION
Can't really test it at the moment, but this should still sort of work, with the exception of determining the architecture of a function from its Language, which might need some enumeration of the options (the current state of `main` will accept just the String the current implementation will make, but that will immediately break as it doesn't have a tokenizer for it).